### PR TITLE
Improves SummaryBlockContentTextView to allow more customization and creates CircularProgressBar view

### DIFF
--- a/library/src/main/java/com/spendesk/grapes/component/content/summary/block/SummaryBlockContentTextView.kt
+++ b/library/src/main/java/com/spendesk/grapes/component/content/summary/block/SummaryBlockContentTextView.kt
@@ -2,14 +2,14 @@ package com.spendesk.grapes.component.content.summary.block
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import androidx.annotation.DrawableRes
 import com.spendesk.grapes.R
 import com.spendesk.grapes.component.content.summary.block.definition.SummaryBlockTitleView
 import com.spendesk.grapes.component.content.summary.block.definition.SummaryBlockView
+import com.spendesk.grapes.databinding.SummaryBlockContentTextBinding
 import com.spendesk.grapes.extensions.visibleOrGone
 import com.spendesk.grapes.internal.libs.glide.loadFromUrl
-import kotlinx.android.synthetic.main.summary_block_content_text.view.*
 
 /**
  * @author Vivien Mahe
@@ -29,31 +29,37 @@ class SummaryBlockContentTextView : SummaryBlockView {
         val imageUrl: String? = null,
         @DrawableRes val imagePlaceholderResId: Int? = null,
         val shouldCircleCropImage: Boolean = false,
+        val isEnabled: Boolean = true
     ) : SummaryBlockView.Configuration(titleConfiguration)
 
+    private var binding = SummaryBlockContentTextBinding.inflate(LayoutInflater.from(context), this, true)
     private val imageRoundedCornerRadius = resources.getDimensionPixelOffset(R.dimen.inlineBlockViewImageCornerRadius)
 
-    init {
-        View.inflate(context, R.layout.summary_block_content_text, this)
-    }
+    override fun getSummaryBlockTitleView(): SummaryBlockTitleView = binding.summaryBlockContentTextTitle
 
-    override fun getSummaryBlockTitleView(): SummaryBlockTitleView = summaryBlockContentTextTitle
+    override fun setEnabled(enabled: Boolean) {
+        super.setEnabled(enabled)
+
+        binding.summaryBlockContentValueText.isEnabled = enabled
+    }
 
     fun updateConfiguration(configuration: Configuration) {
         super.updateConfiguration(configuration)
 
-        summaryBlockContentValueText.visibleOrGone(configuration.value != null)
-        configuration.value?.let { summaryBlockContentValueText.text = it }
+        binding.summaryBlockContentValueText.visibleOrGone(configuration.value != null)
+        configuration.value?.let { binding.summaryBlockContentValueText.text = it }
 
         val shouldDisplayImage = configuration.imageUrl != null || configuration.imagePlaceholderResId != null
-        summaryBlockContentImage.visibleOrGone(shouldDisplayImage)
+        binding.summaryBlockContentImage.visibleOrGone(shouldDisplayImage)
         if (shouldDisplayImage) {
             setImage(url = configuration.imageUrl, placeholderResId = configuration.imagePlaceholderResId, shouldCircleCrop = configuration.shouldCircleCropImage)
         }
+
+        isEnabled = configuration.isEnabled
     }
 
     fun setImage(url: String?, placeholderResId: Int? = 0, shouldCircleCrop: Boolean) {
         val cornerRadius = if (shouldCircleCrop) 0 else imageRoundedCornerRadius
-        summaryBlockContentImage.loadFromUrl(url = url, errorResId = placeholderResId, shouldCircleCrop = shouldCircleCrop, roundedCorners = cornerRadius)
+        binding.summaryBlockContentImage.loadFromUrl(url = url, errorResId = placeholderResId, shouldCircleCrop = shouldCircleCrop, roundedCorners = cornerRadius)
     }
 }

--- a/library/src/main/java/com/spendesk/grapes/component/content/summary/block/definition/SummaryBlockTitleView.kt
+++ b/library/src/main/java/com/spendesk/grapes/component/content/summary/block/definition/SummaryBlockTitleView.kt
@@ -8,10 +8,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.res.ResourcesCompat
 import com.spendesk.grapes.R
 import com.spendesk.grapes.databinding.SummaryBlockContentTitleBinding
-import com.spendesk.grapes.extensions.empty
-import com.spendesk.grapes.extensions.visible
-import com.spendesk.grapes.extensions.visibleOrGone
-import com.spendesk.grapes.extensions.visibleOrInvisible
+import com.spendesk.grapes.extensions.*
 
 /**
  * @author Vivien Mahe
@@ -100,11 +97,16 @@ class SummaryBlockTitleView : ConstraintLayout {
         if (drawable != ResourcesCompat.ID_NULL) {
             binding.summaryBlockContentTitleEndImage.visible()
             binding.summaryBlockContentTitleEndImage.setBackgroundResource(drawable)
+
+            setProgressBarVisibility(false)
+        } else {
+            binding.summaryBlockContentTitleEndImage.gone()
         }
     }
 
     fun setProgressBarVisibility(show: Boolean) {
         binding.summaryBlockContentTitleEndProgressBar.visibleOrGone(show)
+        setTitleEndDrawable(ResourcesCompat.ID_NULL)
     }
 
     private fun setupView(attributeSet: AttributeSet?) {

--- a/library/src/main/java/com/spendesk/grapes/component/content/summary/block/definition/SummaryBlockTitleView.kt
+++ b/library/src/main/java/com/spendesk/grapes/component/content/summary/block/definition/SummaryBlockTitleView.kt
@@ -2,16 +2,16 @@ package com.spendesk.grapes.component.content.summary.block.definition
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import androidx.annotation.DrawableRes
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.res.ResourcesCompat
 import com.spendesk.grapes.R
+import com.spendesk.grapes.databinding.SummaryBlockContentTitleBinding
 import com.spendesk.grapes.extensions.empty
 import com.spendesk.grapes.extensions.visible
 import com.spendesk.grapes.extensions.visibleOrGone
 import com.spendesk.grapes.extensions.visibleOrInvisible
-import kotlinx.android.synthetic.main.summary_block_content_title.view.*
 
 /**
  * @author Vivien Mahe
@@ -33,29 +33,35 @@ class SummaryBlockTitleView : ConstraintLayout {
     }
     //endregion constructors
 
-    class Configuration(
+    data class Configuration(
         val startTitle: CharSequence,
-        var middleTitle: CharSequence? = null,
-        var endTitle: CharSequence? = null,
+        val middleTitle: CharSequence? = null,
+        val endTitle: CharSequence? = null,
         @DrawableRes val drawableEnd: Int = ResourcesCompat.ID_NULL,
-        var isActivated: Boolean = false
+        val isActivated: Boolean = false,
+        val isEnabled: Boolean = true,
+        val showProgressBar: Boolean = false
     )
 
     var onEndTitleTextClicked: (() -> Unit)? = null
         set(onEndTitleTextClicked) {
             field = onEndTitleTextClicked
-            summaryBlockContentTitleEndText.setOnClickListener { field?.invoke() }
+            binding.summaryBlockContentTitleEndText.setOnClickListener { field?.invoke() }
         }
 
-    init {
-        View.inflate(context, R.layout.summary_block_content_title, this)
-    }
+    private var binding = SummaryBlockContentTitleBinding.inflate(LayoutInflater.from(context), this, true)
 
     override fun setActivated(activated: Boolean) {
         super.setActivated(activated)
 
         // Toggle endTitle text style
-        summaryBlockContentTitleEndText.isActivated = activated
+        binding.summaryBlockContentTitleEndText.isActivated = activated
+    }
+
+    override fun setEnabled(enabled: Boolean) {
+        super.setEnabled(enabled)
+
+        binding.summaryBlockContentTitleEndText.isEnabled = enabled
     }
 
     fun updateConfiguration(configuration: Configuration) {
@@ -63,28 +69,34 @@ class SummaryBlockTitleView : ConstraintLayout {
         setTitleMiddleText(configuration.middleTitle)
         setTitleEndText(configuration.endTitle)
         setTitleEndDrawable(configuration.drawableEnd)
+        setProgressBarVisibility(configuration.showProgressBar)
         isActivated = configuration.isActivated
+        isEnabled = configuration.isEnabled
     }
 
     fun setTitleStartText(text: CharSequence?) {
-        summaryBlockContentTitleStartText.text = text ?: String.empty()
+        binding.summaryBlockContentTitleStartText.text = text ?: String.empty()
     }
 
     fun setTitleMiddleText(text: CharSequence?) {
-        summaryBlockContentTitleMiddleText.visibleOrInvisible(text != null)
-        summaryBlockContentTitleMiddleText.text = text
+        binding.summaryBlockContentTitleMiddleText.visibleOrInvisible(text != null)
+        binding.summaryBlockContentTitleMiddleText.text = text
     }
 
     fun setTitleEndText(text: CharSequence?) {
-        summaryBlockContentTitleEndText.visibleOrGone(text != null)
-        summaryBlockContentTitleEndText.text = text
+        binding.summaryBlockContentTitleEndText.visibleOrGone(text != null)
+        binding.summaryBlockContentTitleEndText.text = text
     }
 
     fun setTitleEndDrawable(drawable: Int) {
         if (drawable != ResourcesCompat.ID_NULL) {
-            summaryBlockContentTitleEndImage.visible()
-            summaryBlockContentTitleEndImage.setBackgroundResource(drawable)
+            binding.summaryBlockContentTitleEndImage.visible()
+            binding.summaryBlockContentTitleEndImage.setBackgroundResource(drawable)
         }
+    }
+
+    fun setProgressBarVisibility(show: Boolean) {
+        binding.summaryBlockContentTitleEndProgressBar.visibleOrGone(show)
     }
 
     private fun setupView(attributeSet: AttributeSet?) {

--- a/library/src/main/java/com/spendesk/grapes/component/content/summary/block/definition/SummaryBlockTitleView.kt
+++ b/library/src/main/java/com/spendesk/grapes/component/content/summary/block/definition/SummaryBlockTitleView.kt
@@ -40,6 +40,7 @@ class SummaryBlockTitleView : ConstraintLayout {
         @DrawableRes val drawableEnd: Int = ResourcesCompat.ID_NULL,
         val isActivated: Boolean = false,
         val isEnabled: Boolean = true,
+        val isSelected: Boolean = false,
         val showProgressBar: Boolean = false
     )
 
@@ -64,6 +65,12 @@ class SummaryBlockTitleView : ConstraintLayout {
         binding.summaryBlockContentTitleEndText.isEnabled = enabled
     }
 
+    override fun setSelected(selected: Boolean) {
+        super.setSelected(selected)
+
+        binding.summaryBlockContentTitleEndText.isSelected = selected
+    }
+
     fun updateConfiguration(configuration: Configuration) {
         setTitleStartText(configuration.startTitle)
         setTitleMiddleText(configuration.middleTitle)
@@ -72,6 +79,7 @@ class SummaryBlockTitleView : ConstraintLayout {
         setProgressBarVisibility(configuration.showProgressBar)
         isActivated = configuration.isActivated
         isEnabled = configuration.isEnabled
+        isSelected = configuration.isSelected
     }
 
     fun setTitleStartText(text: CharSequence?) {

--- a/library/src/main/java/com/spendesk/grapes/component/content/summary/block/definition/SummaryBlockTitleView.kt
+++ b/library/src/main/java/com/spendesk/grapes/component/content/summary/block/definition/SummaryBlockTitleView.kt
@@ -106,7 +106,7 @@ class SummaryBlockTitleView : ConstraintLayout {
 
     fun setProgressBarVisibility(show: Boolean) {
         binding.summaryBlockContentTitleEndProgressBar.visibleOrGone(show)
-        setTitleEndDrawable(ResourcesCompat.ID_NULL)
+        if (show) setTitleEndDrawable(ResourcesCompat.ID_NULL)
     }
 
     private fun setupView(attributeSet: AttributeSet?) {

--- a/library/src/main/java/com/spendesk/grapes/loader/CircularProgressBar.kt
+++ b/library/src/main/java/com/spendesk/grapes/loader/CircularProgressBar.kt
@@ -1,0 +1,84 @@
+package com.spendesk.grapes.loader
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import androidx.constraintlayout.widget.ConstraintLayout
+import com.spendesk.grapes.R
+import com.spendesk.grapes.databinding.FragmentBottomSheetSearchableBinding
+import com.spendesk.grapes.databinding.LoaderCircularProgressbarBinding
+import java.util.*
+import kotlin.math.roundToInt
+
+/**
+ * @author Vivien Mahe
+ * @since 28/10/2021
+ */
+class CircularProgressBar : ConstraintLayout {
+
+    constructor(context: Context) : super(context) {
+        setupView(null)
+    }
+
+    constructor(context: Context, attributeSet: AttributeSet?) : super(context, attributeSet) {
+        setupView(attributeSet)
+    }
+
+    constructor(context: Context, attributeSet: AttributeSet?, defStyleAttr: Int) : super(context, attributeSet, defStyleAttr) {
+        setupView(attributeSet)
+    }
+
+    enum class Size(val position: Int) {
+        NORMAL(0),
+        SMALL(1);
+
+        companion object {
+            fun fromPosition(position: Int): Size {
+                return try {
+                    values().first { it.position == position }
+                } catch (exception: NoSuchElementException) {
+                    getDefault()
+                }
+            }
+
+            fun getDefault() = NORMAL
+        }
+    }
+
+    private var binding = LoaderCircularProgressbarBinding.inflate(LayoutInflater.from(context), this, true)
+
+    private fun setupView(attributeSet: AttributeSet?) {
+        attributeSet?.let {
+            with(context.obtainStyledAttributes(it, R.styleable.CircularProgressBar)) {
+                val size = Size.fromPosition(getInt(R.styleable.CircularProgressBar_grapesProgressBarSize, Size.getDefault().position))
+                recycle()
+
+                setSize(size)
+            }
+        }
+    }
+
+    private fun setSize(size: Size) {
+        when (size) {
+            Size.NORMAL -> R.dimen.circularProgressBarNormalSize
+            Size.SMALL -> R.dimen.circularProgressBarSmallSize
+        }.let { sizeResId ->
+            val dimen = resources.getDimension(sizeResId).roundToInt()
+
+            with(binding.circularProgressBarMain) {
+                minWidth = dimen
+                minHeight = dimen
+                maxWidth = dimen
+                maxHeight = dimen
+            }
+
+            with(binding.circularProgressBarSecondary) {
+                minWidth = dimen
+                minHeight = dimen
+                maxWidth = dimen
+                maxHeight = dimen
+            }
+        }
+    }
+}

--- a/library/src/main/res/color/summary_block_content_text_value_text.xml
+++ b/library/src/main/res/color/summary_block_content_text_value_text.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/inlineBlockViewValueTextColorDefault" android:state_enabled="true" />
+    <item android:color="@color/inlineBlockViewValueTextColorDisabled" android:state_enabled="false" />
+</selector>

--- a/library/src/main/res/color/summary_block_content_title_end_text.xml
+++ b/library/src/main/res/color/summary_block_content_title_end_text.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="@color/inlineBlockTitleActionTextColorEnabled" android:state_activated="true" android:state_enabled="true" />
-    <item android:color="@color/inlineBlockTitleActionTextColorDefault" android:state_activated="false" android:state_enabled="true" />
-    <item android:color="@color/inlineBlockTitleActionTextColorDisabled" android:state_activated="false" android:state_enabled="false" />
+    <item android:color="@color/inlineBlockTitleActionTextColorEnabled" android:state_activated="true" android:state_enabled="true" android:state_selected="false" />
+    <item android:color="@color/inlineBlockTitleActionTextColorDefault" android:state_activated="false" android:state_enabled="true" android:state_selected="false"  />
+    <item android:color="@color/inlineBlockTitleActionTextColorDisabled" android:state_activated="false" android:state_enabled="false" android:state_selected="false" />
+    <item android:color="@color/inlineBlockTitleActionTextColorSelected" android:state_activated="false" android:state_enabled="true" android:state_selected="true" />
 </selector>

--- a/library/src/main/res/layout/loader_circular_progressbar.xml
+++ b/library/src/main/res/layout/loader_circular_progressbar.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ProgressBar
+        android:id="@+id/circularProgressBarSecondary"
+        style="@style/CircularProgressBarSecondary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ProgressBar
+        android:id="@+id/circularProgressBarMain"
+        style="@style/CircularProgressBarMain"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/library/src/main/res/layout/summary_block_content_title.xml
+++ b/library/src/main/res/layout/summary_block_content_title.xml
@@ -41,7 +41,7 @@
         style="@style/SummaryBlockContentTitleEndText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/partialContentBlockEndImageMarginStart"
+        android:layout_marginEnd="@dimen/partialContentBlockTextEndMarginEnd"
         android:layout_marginStart="@dimen/inlineBlockViewTextMarginHorz"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/summaryBlockContentTitleEndRightBarrier"

--- a/library/src/main/res/layout/summary_block_content_title.xml
+++ b/library/src/main/res/layout/summary_block_content_title.xml
@@ -23,41 +23,59 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/summaryBlockContentMiddleTitleTextMarginStart"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/summaryBlockContentTitleEndBarrier"
+        app:layout_constraintEnd_toStartOf="@id/summaryBlockContentTitleEndLeftBarrier"
         app:layout_constraintStart_toEndOf="@id/summaryBlockContentTitleStartText"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="• Optional"
         tools:visibility="visible" />
 
     <androidx.constraintlayout.widget.Barrier
-        android:id="@+id/summaryBlockContentTitleEndBarrier"
+        android:id="@+id/summaryBlockContentTitleEndLeftBarrier"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:barrierDirection="start"
-        app:constraint_referenced_ids="summaryBlockContentTitleEndText,summaryBlockContentTitleEndImage" />
+        app:constraint_referenced_ids="summaryBlockContentTitleEndText" />
 
     <TextView
         android:id="@+id/summaryBlockContentTitleEndText"
         style="@style/SummaryBlockContentTitleEndText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/partialContentBlockEndImageMarginStart"
         android:layout_marginStart="@dimen/inlineBlockViewTextMarginHorz"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/summaryBlockContentTitleEndImage"
-        app:layout_constraintStart_toEndOf="@+id/summaryBlockContentTitleEndBarrier"
+        app:layout_constraintEnd_toStartOf="@id/summaryBlockContentTitleEndRightBarrier"
+        app:layout_constraintStart_toEndOf="@+id/summaryBlockContentTitleEndLeftBarrier"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Action"
         tools:visibility="visible" />
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/summaryBlockContentTitleEndRightBarrier"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="end"
+        app:constraint_referenced_ids="summaryBlockContentTitleEndText" />
 
     <ImageView
         android:id="@+id/summaryBlockContentTitleEndImage"
         style="@style/SummaryBlockContentTitleEndImage"
         android:layout_width="@dimen/partialContentBlockEndImageSize"
         android:layout_height="@dimen/partialContentBlockEndImageSize"
-        android:layout_marginStart="@dimen/partialContentBlockEndImageMarginStart"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/summaryBlockContentTitleEndText"
+        app:layout_constraintStart_toEndOf="@id/summaryBlockContentTitleEndRightBarrier"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible" />
+
+    <com.spendesk.grapes.loader.CircularProgressBar
+        android:id="@+id/summaryBlockContentTitleEndProgressBar"
+        style="@style/SummaryBlockContentTitleEndProgressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/summaryBlockContentTitleEndRightBarrier"
         app:layout_constraintTop_toTopOf="parent"
         tools:visibility="visible" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/library/src/main/res/values/attrs_loaders.xml
+++ b/library/src/main/res/values/attrs_loaders.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <declare-styleable name="CircularProgressBar">
+        <attr name="grapesProgressBarSize" format="enum|reference">
+            <enum name="normal" value="0" />
+            <enum name="small" value="1" />
+        </attr>
+    </declare-styleable>
+
+</resources>

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -117,7 +117,8 @@
     <color name="inlineBlockTitleActionTextColorDefault">@color/mainNeutralDarker</color>
     <color name="inlineBlockTitleActionTextColorDisabled">@color/mainNeutralDark</color>
     <color name="inlineBlockViewKeyTextColor">@color/mainNeutralDarker</color>
-    <color name="inlineBlockViewValueTextColor">@color/mainComplementary</color>
+    <color name="inlineBlockViewValueTextColorDefault">@color/mainComplementary</color>
+    <color name="inlineBlockViewValueTextColorDisabled">@color/mainNeutralDark</color>
     <color name="mapBlockAddressTextColor">@color/mainComplementary</color>
 
     <color name="responsibilityCenterGaugeViewContainerBackgroundColor">@color/white</color>

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -113,6 +113,7 @@
     <color name="summaryBlockContentMiddleTitleTextColor">@color/mainNeutralDarker</color>
 
     <color name="partialContentBlockTitleTextColor">@color/mainComplementary</color>
+    <color name="inlineBlockTitleActionTextColorSelected">@color/mainWarningNormal</color>
     <color name="inlineBlockTitleActionTextColorEnabled">@color/mainPrimaryNormal</color>
     <color name="inlineBlockTitleActionTextColorDefault">@color/mainNeutralDarker</color>
     <color name="inlineBlockTitleActionTextColorDisabled">@color/mainNeutralDark</color>

--- a/library/src/main/res/values/colors_loaders.xml
+++ b/library/src/main/res/values/colors_loaders.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- region CircularProgressBar -->
+
+    <color name="circularProgressBarMainColor">@color/mainBrandPeach</color>
+    <color name="circularProgressBarSecondaryColor">@color/mainPrimaryNormal</color>
+
+    <!-- endregion CircularProgressBar -->
+
+</resources>

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -131,8 +131,9 @@
     <dimen name="partialContentBlockTitleMarginHorz">@dimen/normalMargin</dimen>
     <dimen name="partialContentBlockTitleMarginVert">@dimen/normalMargin</dimen>
     <dimen name="partialContentBlockTitleTextSize">14sp</dimen>
-    <dimen name="partialContentBlockEndImageSize">32dp</dimen>
-    <dimen name="partialContentBlockEndImageMarginStart">@dimen/smallMargin</dimen>
+    <dimen name="partialContentBlockEndImageSize">16dp</dimen>
+    <dimen name="partialContentBlockTextEndMarginEnd">@dimen/smallMargin</dimen>
+    <dimen name="partialContentBlockTextEndPaddingVert">@dimen/tinyMargin</dimen>
 
     <dimen name="inlineBlockViewTextMarginHorz">@dimen/bigMargin</dimen>
     <dimen name="inlineBlockViewKeyTextSize">16sp</dimen>

--- a/library/src/main/res/values/dimens_loaders.xml
+++ b/library/src/main/res/values/dimens_loaders.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- region CircularProgressBar -->
+
+    <dimen name="circularProgressBarSmallSize">16dp</dimen>
+    <dimen name="circularProgressBarNormalSize">48dp</dimen>
+
+    <!-- endregion CircularProgressBar -->
+
+</resources>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -90,6 +90,8 @@
     </style>
 
     <style name="SummaryBlockContentTitleEndText">
+        <item name="android:paddingTop">@dimen/partialContentBlockTextEndPaddingVert</item>
+        <item name="android:paddingBottom">@dimen/partialContentBlockTextEndPaddingVert</item>
         <item name="android:visibility">gone</item>
         <item name="android:fontFamily">@font/gt_america_bold</item>
         <item name="android:textColor">@color/summary_block_content_title_end_text</item>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -104,6 +104,12 @@
     <style name="SummaryBlockContentTitleEndImage">
         <item name="android:visibility">gone</item>
     </style>
+
+    <style name="SummaryBlockContentTitleEndProgressBar">
+        <item name="android:visibility">gone</item>
+        <item name="grapesProgressBarSize">small</item>
+        <item name="android:gravity">center</item>
+    </style>
     <!-- endregion Summary Block Content -->
 
     <!-- region Inline Block -->
@@ -121,7 +127,7 @@
         <item name="android:gravity">end</item>
         <item name="android:singleLine">true</item>
         <item name="android:ellipsize">end</item>
-        <item name="android:textColor">@color/inlineBlockViewValueTextColor</item>
+        <item name="android:textColor">@color/inlineBlockViewValueTextColorDefault</item>
         <item name="android:textSize">@dimen/inlineBlockViewValueTextSize</item>
     </style>
     <!-- endregion Inline Block -->
@@ -185,7 +191,7 @@
 
     <style name="SummaryBlockTextValue">
         <item name="android:fontFamily">@font/gt_america</item>
-        <item name="android:textColor">@color/inlineBlockViewValueTextColor</item>
+        <item name="android:textColor">@color/summary_block_content_text_value_text</item>
         <item name="android:textSize">@dimen/inlineBlockViewValueTextSize</item>
     </style>
 

--- a/library/src/main/res/values/styles_loaders.xml
+++ b/library/src/main/res/values/styles_loaders.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- region CircularProgressBar -->
+
+    <style name="CircularProgressBar" parent="@style/Widget.AppCompat.ProgressBar">
+        <item name="android:indeterminate">true</item>
+        <item name="android:background">@android:color/transparent</item>
+    </style>
+
+    <style name="CircularProgressBarMain" parent="@style/CircularProgressBar">
+        <item name="android:indeterminateTint">@color/circularProgressBarMainColor</item>
+        <item name="android:rotation">90</item>
+    </style>
+
+    <style name="CircularProgressBarSecondary" parent="@style/CircularProgressBar">
+        <item name="android:indeterminateTint">@color/circularProgressBarSecondaryColor</item>
+    </style>
+
+    <!-- endregion CircularProgressBar -->
+
+</resources>

--- a/sample/src/main/java/com/spendesk/grapes/samples/entity/HomeTabItem.kt
+++ b/sample/src/main/java/com/spendesk/grapes/samples/entity/HomeTabItem.kt
@@ -39,4 +39,7 @@ sealed class HomeTabItem : Parcelable {
 
     @Parcelize
     object BottomSheets : HomeTabItem()
+
+    @Parcelize
+    object Loaders : HomeTabItem()
 }

--- a/sample/src/main/java/com/spendesk/grapes/samples/home/HomeActivityViewModel.kt
+++ b/sample/src/main/java/com/spendesk/grapes/samples/home/HomeActivityViewModel.kt
@@ -26,7 +26,7 @@ class HomeActivityViewModel @Inject constructor() : ViewModel() {
         when (lifecycle) {
             Lifecycle.State.INITIALIZED -> {
                 updateHomeTabItem.onNext(
-                    listOf(HomeTabItem.Buttons, HomeTabItem.Cards, HomeTabItem.Selectors, HomeTabItem.Inputs, HomeTabItem.Lists, HomeTabItem.Contents, HomeTabItem.BottomSheets)
+                    listOf(HomeTabItem.Buttons, HomeTabItem.Cards, HomeTabItem.Selectors, HomeTabItem.Inputs, HomeTabItem.Lists, HomeTabItem.Contents, HomeTabItem.BottomSheets, HomeTabItem.Loaders)
                 )
                 // At some point, the whole list should be sent when handling all the views in the app.
                 // *HomeTabItem::class.nestedClasses.map { it.objectInstance as HomeTabItem }.toTypedArray()

--- a/sample/src/main/java/com/spendesk/grapes/samples/home/HomePagerAdapter.kt
+++ b/sample/src/main/java/com/spendesk/grapes/samples/home/HomePagerAdapter.kt
@@ -25,6 +25,7 @@ class HomePagerAdapter(
             is HomeTabItem.Lists -> ListsFragment.newInstance()
             is HomeTabItem.Contents -> ContentsFragment.newInstance()
             is HomeTabItem.BottomSheets -> BottomSheetsFragment.newInstance()
+            is HomeTabItem.Loaders -> LoadersFragment.newInstance()
             is HomeTabItem.Avatars,
             is HomeTabItem.Messages,
             is HomeTabItem.Modals -> throw IllegalStateException("Cannot resolve the item (name: ${item::class.java.simpleName}. This item is not yet resolved is not handled")

--- a/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/ContentsFragment.kt
+++ b/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/ContentsFragment.kt
@@ -107,9 +107,12 @@ class ContentsFragment : Fragment(R.layout.fragment_home_contents) {
                 configuration = SummaryBlockContentTextView.Configuration(
                     titleConfiguration = SummaryBlockTitleView.Configuration(
                         startTitle = "Description",
-                        endTitle = "Edit"
+                        endTitle = "Saving",
+                        isEnabled = false,
+                        showProgressBar = true
                     ),
-                    value = "Room booked in Lyon for 3 days to Le Progrès and organize a team building with Lyon’s team"
+                    value = "Room booked in Lyon for 3 days to Le Progrès and organize a team building with Lyon’s team",
+                    isEnabled = false
                 )
             )
             onEndTitleTextClicked = { requireActivity().shortToaster("Edit Text with value") }

--- a/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/ContentsFragment.kt
+++ b/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/ContentsFragment.kt
@@ -46,7 +46,7 @@ class ContentsFragment : Fragment(R.layout.fragment_home_contents) {
                         startTitle = "Trip details",
                         middleTitle = " • Optional",
                         endTitle = "Action",
-                        drawableEnd = R.drawable.ic_warning_circle_stroke,
+                        drawableEnd = R.drawable.ic_warning,
                         isActivated = true
                     ),
                     mapImageUrl = String.empty(), // TODO Change this when we actually use Mapbox
@@ -101,7 +101,7 @@ class ContentsFragment : Fragment(R.layout.fragment_home_contents) {
             onEndTitleTextClicked = { requireActivity().shortToaster("Edit Text with value and image") }
         }
 
-        // Text with value
+        // Text with value disabled
         with(homeButtonSectionTextWithValueBlock) {
             updateConfiguration(
                 configuration = SummaryBlockContentTextView.Configuration(
@@ -113,6 +113,22 @@ class ContentsFragment : Fragment(R.layout.fragment_home_contents) {
                     ),
                     value = "Room booked in Lyon for 3 days to Le Progrès and organize a team building with Lyon’s team",
                     isEnabled = false
+                )
+            )
+            onEndTitleTextClicked = { requireActivity().shortToaster("Edit Text with value") }
+        }
+
+        // Text with value selected
+        with(homeButtonSectionTextWithValueSelectedBlock) {
+            updateConfiguration(
+                configuration = SummaryBlockContentTextView.Configuration(
+                    titleConfiguration = SummaryBlockTitleView.Configuration(
+                        startTitle = "Description",
+                        endTitle = "Error",
+                        isSelected = true,
+                        drawableEnd = R.drawable.ic_warning
+                    ),
+                    value = "Another example of a text content block but this time with a selected value, which will change the color of the title's end text"
                 )
             )
             onEndTitleTextClicked = { requireActivity().shortToaster("Edit Text with value") }

--- a/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/LoadersFragment.kt
+++ b/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/LoadersFragment.kt
@@ -7,18 +7,18 @@ import com.spendesk.grapes.samples.R
 import kotlinx.android.synthetic.main.view_home_header.*
 
 /**
- * @author danyboucanova
- * @since 12/29/20
+ * @author Vivien Mahe
+ * @since 28/10/2021
  */
-class ButtonsFragment : Fragment(R.layout.fragment_home_buttons) {
+class LoadersFragment : Fragment(R.layout.fragment_home_loaders) {
 
     companion object {
-        fun newInstance() = ButtonsFragment()
+        fun newInstance() = LoadersFragment()
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        homeGenericHeaderTitle.text = context?.getString(R.string.buttons)
+        homeGenericHeaderTitle.text = context?.getString(R.string.loaders)
     }
 }

--- a/sample/src/main/res/layout/fragment_home_contents.xml
+++ b/sample/src/main/res/layout/fragment_home_contents.xml
@@ -154,7 +154,7 @@
                     android:layout_marginStart="@dimen/homeSectionSubtitleMarginHorz"
                     android:layout_marginTop="@dimen/homeSectionSubtitleMarginVert"
                     android:layout_marginEnd="@dimen/homeSectionSubtitleMarginHorz"
-                    android:text="@string/contentTextWithValue"
+                    android:text="@string/contentTextWithValueDisabled"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/homeButtonSectionTextWithValueAndImageBlock" />
@@ -171,6 +171,30 @@
                     app:layout_constraintTop_toBottomOf="@id/homeButtonSectionTextWithValueSubtitle" />
 
                 <TextView
+                    android:id="@+id/homeButtonSectionTextWithValueSelectedSubtitle"
+                    style="@style/HomeGenericSubtitle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/homeSectionSubtitleMarginHorz"
+                    android:layout_marginTop="@dimen/homeSectionSubtitleMarginVert"
+                    android:layout_marginEnd="@dimen/homeSectionSubtitleMarginHorz"
+                    android:text="@string/contentTextWithValueSelected"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/homeButtonSectionTextWithValueBlock" />
+
+                <com.spendesk.grapes.component.content.summary.block.SummaryBlockContentTextView
+                    android:id="@+id/homeButtonSectionTextWithValueSelectedBlock"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_marginStart="@dimen/homeSectionComponentMarginHorz"
+                    android:layout_marginTop="@dimen/homeSectionComponentMarginVert"
+                    android:layout_marginEnd="@dimen/homeSectionComponentMarginHorz"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/homeButtonSectionTextWithValueSelectedSubtitle" />
+
+                <TextView
                     android:id="@+id/homeButtonSectionTextWithoutValueSubtitle"
                     style="@style/HomeGenericSubtitle"
                     android:layout_width="0dp"
@@ -181,7 +205,7 @@
                     android:text="@string/contentTextWithoutValue"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/homeButtonSectionTextWithValueBlock" />
+                    app:layout_constraintTop_toBottomOf="@id/homeButtonSectionTextWithValueSelectedBlock" />
 
                 <com.spendesk.grapes.component.content.summary.block.SummaryBlockContentTextView
                     android:id="@+id/homeButtonSectionTextWithoutValueBlock"

--- a/sample/src/main/res/layout/fragment_home_loaders.xml
+++ b/sample/src/main/res/layout/fragment_home_loaders.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/HomeGenericScrollViewContainer"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp">
+
+        <include layout="@layout/view_home_header" />
+
+        <!-- region CircularProgressBar -->
+
+        <TextView
+            android:id="@+id/homeLoadersSectionCircularProgressBarTitleText"
+            style="@style/HomeGenericTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/homeSectionTitleMarginHorz"
+            android:layout_marginTop="@dimen/homeSectionTitleMarginVert"
+            android:layout_marginEnd="@dimen/homeSectionTitleMarginHorz"
+            android:text="@string/loadersCircularProgressBar"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/homeGenericHeaderBackground" />
+
+        <com.spendesk.grapes.BucketView
+            android:id="@+id/homeLoadersSectionCircularProgressBarBucketView"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/homeSectionBucketViewMarginHorz"
+            android:layout_marginTop="@dimen/homeSectionBucketViewMarginVert"
+            android:layout_marginEnd="@dimen/homeSectionBucketViewMarginHorz"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/homeLoadersSectionCircularProgressBarTitleText">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <TextView
+                    android:id="@+id/homeLoadersSectionCircularProgressBarNormalSubtitle"
+                    style="@style/HomeGenericSubtitle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/homeSectionSubtitleMarginHorz"
+                    android:layout_marginTop="@dimen/homeSectionSubtitleMarginVert"
+                    android:layout_marginEnd="@dimen/homeSectionSubtitleMarginHorz"
+                    android:text="@string/loadersCircularProgressBarNormal"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <com.spendesk.grapes.loader.CircularProgressBar
+                    android:id="@+id/homeLoadersSectionCircularProgressBarNormalButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/homeSectionComponentMarginHorz"
+                    android:layout_marginTop="@dimen/homeSectionComponentMarginVert"
+                    android:layout_marginEnd="@dimen/homeSectionComponentMarginHorz"
+                    app:grapesProgressBarSize="normal"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/homeLoadersSectionCircularProgressBarNormalSubtitle" />
+
+                <TextView
+                    android:id="@+id/homeLoadersSectionCircularProgressBarSmallSubtitle"
+                    style="@style/HomeGenericSubtitle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/homeSectionSubtitleMarginHorz"
+                    android:layout_marginTop="@dimen/homeSectionSubtitleMarginVert"
+                    android:layout_marginEnd="@dimen/homeSectionSubtitleMarginHorz"
+                    android:text="@string/loadersCircularProgressBarSmall"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/homeLoadersSectionCircularProgressBarNormalButton" />
+
+                <com.spendesk.grapes.loader.CircularProgressBar
+                    android:id="@+id/homeLoadersSectionCircularProgressBarSmallButton"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_marginStart="@dimen/homeSectionComponentMarginHorz"
+                    android:layout_marginTop="@dimen/homeSectionComponentMarginVert"
+                    android:layout_marginEnd="@dimen/homeSectionComponentMarginHorz"
+                    android:layout_marginBottom="@dimen/bigMargin"
+                    app:grapesProgressBarSize="small"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/homeLoadersSectionCircularProgressBarSmallSubtitle" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.spendesk.grapes.BucketView>
+
+        <!-- endregion CircularProgressBar -->
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="lists" translatable="false">Lists</string>
     <string name="contents" translatable="false">Contents</string>
     <string name="bottomSheets" translatable="false">Bottom Sheets</string>
+    <string name="loaders" translatable="false">Loaders</string>
 
     <string name="primary" translatable="false">Primary</string>
     <string name="secondary" translatable="false">Secondary</string>
@@ -60,5 +61,10 @@
     <string name="bottomSheetSearchableViewStateContentButton" translatable="false">Searchable with viewState.Content</string>
     <string name="bottomSheetSearchableViewStateEmptyButton" translatable="false">Searchable with viewState.Empty</string>
     <string name="bottomSheetsEditableTitle" translatable="false">Editable bottom sheet</string>
+
+    <!-- Loaders -->
+    <string name="loadersCircularProgressBar" translatable="false">CircularProgressBar</string>
+    <string name="loadersCircularProgressBarNormal" translatable="false">Normal</string>
+    <string name="loadersCircularProgressBarSmall" translatable="false">Small</string>
 
 </resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -53,7 +53,8 @@
     <string name="contentMapCompact" translatable="false">Compact</string>
     <string name="contentText" translatable="false">Text</string>
     <string name="contentTextWithValueAndImage" translatable="false">With value and image</string>
-    <string name="contentTextWithValue" translatable="false">With value</string>
+    <string name="contentTextWithValueDisabled" translatable="false">With value disabled</string>
+    <string name="contentTextWithValueSelected" translatable="false">With value selected</string>
     <string name="contentTextWithoutValue" translatable="false">Without value</string>
 
     <!-- BottomSheets -->


### PR DESCRIPTION
- Improves SummaryBlockContentTextView to handle the `isEnabled` state.
- Improves SummaryBlockTitleView to handle the `isEnabled`, `isActivated`, `isSelected` states and the ability to show a small `CircularProgressBar`.
- Creates a `CircularProgressBar` view class that displays our typical loader (2 colors ProgressBar) which comes in two sizes: normal and small.
- Adds a "Loaders" tab in the Grapes sample to display the small and normal `CircularProgressBar`s.

![Screenshot_20211103-121129](https://user-images.githubusercontent.com/596985/140050496-45aa9cc7-bf2c-44be-a4f3-4f95860b998a.png)
