### PR TITLE
[Bug] - bug/AA-1352-registration-code-multiple-lines-small-screens

### DIFF
--- a/library/src/main/res/values-hdpi/dimens.xml
+++ b/library/src/main/res/values-hdpi/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="registrationCodeViewTextLetterSpacing">0.20</dimen>
+    <dimen name="registrationCodeViewTextSize">18sp</dimen>
+</resources>

--- a/library/src/main/res/values-xhdpi/dimens.xml
+++ b/library/src/main/res/values-xhdpi/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="registrationCodeViewTextLetterSpacing">0.25</dimen>
+    <dimen name="registrationCodeViewTextSize">20sp</dimen>
+</resources>

--- a/sample/src/main/res/layout/fragment_home_cards.xml
+++ b/sample/src/main/res/layout/fragment_home_cards.xml
@@ -116,7 +116,6 @@
             android:layout_marginTop="@dimen/homeSectionBucketViewMarginVert"
             android:layout_marginEnd="@dimen/homeSectionBucketViewMarginHorz"
             android:layout_marginBottom="@dimen/homeSectionBucketViewMarginVert"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/homeCardSectionPlasticCardTitleText">
@@ -200,6 +199,51 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/homeCardSectionPlasticCardAlertSubtitle" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.spendesk.grapes.BucketView>
+
+        <com.spendesk.grapes.BucketView
+            android:id="@+id/homeCardSectionRegistrationCodeBucketView"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/homeSectionBucketViewMarginHorz"
+            android:layout_marginTop="@dimen/homeSectionBucketViewMarginVert"
+            android:layout_marginEnd="@dimen/homeSectionBucketViewMarginHorz"
+            android:layout_marginBottom="@dimen/homeSectionBucketViewMarginVert"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/homeCardSectionPlasticCardBucketView">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <TextView
+                    android:id="@+id/homeCardSectionRegistrationCodeNormalSubtitle"
+                    style="@style/HomeGenericSubtitle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/homeSectionSubtitleMarginHorz"
+                    android:layout_marginTop="@dimen/homeSectionSubtitleMarginVert"
+                    android:layout_marginEnd="@dimen/homeSectionSubtitleMarginHorz"
+                    android:text="@string/cardNormal"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <com.spendesk.grapes.RegistrationCodeView
+                    android:layout_width="0dp"
+                    android:layout_height="56dp"
+                    app:layout_constraintTop_toBottomOf="@+id/homeCardSectionRegistrationCodeNormalSubtitle"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    android:layout_marginStart="@dimen/homeSectionSubtitleMarginHorz"
+                    android:layout_marginTop="@dimen/homeSectionSubtitleMarginVert"
+                    android:layout_marginBottom="@dimen/homeSectionSubtitleMarginVert"
+                    android:layout_marginEnd="@dimen/homeSectionSubtitleMarginHorz"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent" />
+
             </androidx.constraintlayout.widget.ConstraintLayout>
         </com.spendesk.grapes.BucketView>
         <!-- endregion plastic card -->


### PR DESCRIPTION
- Add according dimens for small screens to render the registration code
  vie
  Before:
<img width="303" alt="Screenshot 2021-11-08 at 10 56 34" src="https://user-images.githubusercontent.com/9486557/140722362-feb16086-b0fb-461b-8b19-818298c9f7f6.png">

After
<img width="325" alt="Screenshot 2021-11-08 at 10 57 07" src="https://user-images.githubusercontent.com/9486557/140722391-8fc05fbc-7c9c-46a3-9f23-55733caa35b9.png">
:
