### PR TITLE
Fix item alignments

### DIFF
--- a/library/src/main/res/layout/component_simple_entry_item.xml
+++ b/library/src/main/res/layout/component_simple_entry_item.xml
@@ -100,7 +100,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:barrierDirection="start"
-        app:constraint_referenced_ids="simpleEntryItemTitleEndOptional,simpleEntryItemTitleEnd" />
+        app:constraint_referenced_ids="simpleEntryItemTitleEndOptional,simpleEntryItemTitleEnd, simpleEntryItemDescriptionEnd" />
 
     <androidx.constraintlayout.widget.Barrier
         android:id="@+id/simpleEntryItemDescriptionEndStartBarrier"
@@ -192,6 +192,7 @@
         app:layout_constraintBottom_toTopOf="@id/simpleEntryItemDescriptionEnd"
         app:layout_constraintEnd_toStartOf="@id/simpleEntryItemTitleEnd"
         app:layout_constraintStart_toEndOf="@+id/simpleEntryItemTitleEndStartBarrier"
+        app:layout_constraintHorizontal_bias="1"
         app:layout_constraintTop_toBottomOf="@id/simpleEntryItemContentStartHeightGuideline"
         tools:text="$68,34 • "
         tools:visibility="visible" />
@@ -204,9 +205,8 @@
         android:layout_marginEnd="@dimen/listEntryItemMarginEnd"
         app:layout_constraintBottom_toTopOf="@id/simpleEntryItemDescriptionEnd"
         app:layout_constraintEnd_toEndOf="@id/simpleEntryItemBadgeBarrier"
-        app:layout_constraintStart_toEndOf="@id/simpleEntryItemTitleEndOptional"
         app:layout_constraintTop_toBottomOf="@id/simpleEntryItemContentStartHeightGuideline"
-        tools:text="71,03 €"
+        tools:text="7 €"
         tools:visibility="visible" />
 
     <View
@@ -243,6 +243,7 @@
         android:layout_marginEnd="@dimen/listEntryItemMarginEnd"
         app:layout_constraintBottom_toTopOf="@id/simpleEntryItemContentDescriptionMaxEndHeightGuideline"
         app:layout_constraintEnd_toEndOf="@id/simpleEntryItemBadgeBarrier"
+        app:layout_constraintHorizontal_bias="1"
         app:layout_constraintStart_toEndOf="@+id/simpleEntryItemDescriptionEndStartBarrier"
         app:layout_constraintTop_toBottomOf="@+id/simpleEntryItemTitleEnd"
         tools:text="12 Sept."
@@ -275,8 +276,8 @@
     <com.spendesk.grapes.BadgeView
         android:id="@+id/simpleEntryItemBadge"
         android:layout_width="wrap_content"
-        android:layout_marginEnd="@dimen/listEntryItemBadgeMarginEnd"
         android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/listEntryItemBadgeMarginEnd"
         app:layout_constraintBottom_toBottomOf="@id/simpleEntryItemMinHeightGuideline"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/simpleEntryItemBadgeBarrier"

--- a/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/ListsFragment.kt
+++ b/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/ListsFragment.kt
@@ -103,9 +103,54 @@ class ListsFragment : Fragment(R.layout.fragment_home_lists) {
         val item9Configuration = SimpleEntryItemView.Configuration(
             placeholderPrimaryImage = R.drawable.ic_pencil,
             shouldCircleCropPrimaryImage = true,
-            titleStart = "Payments style",
-            titleEnd = "73,69 €",
+            titleStart = "Very expansive",
+            titleEnd = "73242534,69 €",
             descriptionStart = "Super longue descritpion qui va passer sous le prix parce qu'elle est trop grosse",
+        )
+
+        val item10Configuration = SimpleEntryItemView.Configuration(
+            placeholderPrimaryImage = R.drawable.ic_pencil,
+            shouldCircleCropPrimaryImage = true,
+            titleStart = "Kebab",
+            titleEnd = "7,69 €",
+            descriptionStart = "Super longue descritpion qui va passer sous le prix parce qu'elle est trop grosse",
+        )
+
+        val item11Configuration = SimpleEntryItemView.Configuration(
+            placeholderPrimaryImage = R.drawable.ic_pencil,
+            shouldCircleCropPrimaryImage = true,
+            titleStart = "Very expansive with date",
+            titleEnd = "73242534,69 €",
+            descriptionStart = "Super longue descritpion qui va passer sous le prix parce qu'elle est trop grosse",
+            descriptionEnd = "14 June"
+
+        )
+
+        val item12Configuration = SimpleEntryItemView.Configuration(
+            placeholderPrimaryImage = R.drawable.ic_pencil,
+            shouldCircleCropPrimaryImage = true,
+            titleStart = "Kebab with date in the cold with a mustache doing a backflip",
+            titleEnd = "7 €",
+            descriptionStart = "Super longue descritpion qui va passer sous le prix parce qu'elle est trop grosse",
+            descriptionEnd = "14 November"
+        )
+
+        val item13Configuration = SimpleEntryItemView.Configuration(
+            placeholderPrimaryImage = R.drawable.ic_pencil,
+            shouldCircleCropPrimaryImage = true,
+            titleStart = "Kebab with date in the cold with a mustache doing a backflip",
+            descriptionStart = "Super longue descritpion qui va passer sous le prix parce qu'elle est trop grosse",
+            descriptionEnd = "14 November"
+        )
+
+        val item14Configuration = SimpleEntryItemView.Configuration(
+            placeholderPrimaryImage = R.drawable.ic_pencil,
+            shouldCircleCropPrimaryImage = true,
+            titleStart = "Kebab with date in the cold with a mustache doing a backflip",
+            titleEnd = "7 €",
+            titleEndOptional = "$68,34",
+            descriptionStart = "Super longue descritpion qui va passer sous le prix parce qu'elle est trop grosse",
+            descriptionEnd = "14 November"
         )
 
         // Sections
@@ -135,7 +180,12 @@ class ListsFragment : Fragment(R.layout.fragment_home_lists) {
                 SimpleListModel.Item(id = "6", configuration = item6Configuration),
                 SimpleListModel.Item(id = "7", configuration = item7Configuration),
                 SimpleListModel.Item(id = "8", configuration = item8Configuration),
-                SimpleListModel.Item(id = "9", configuration = item9Configuration)
+                SimpleListModel.Item(id = "9", configuration = item9Configuration),
+                SimpleListModel.Item(id = "10", configuration = item10Configuration),
+                SimpleListModel.Item(id = "11", configuration = item11Configuration),
+                SimpleListModel.Item(id = "12", configuration = item12Configuration),
+                SimpleListModel.Item(id = "13", configuration = item13Configuration),
+                SimpleListModel.Item(id = "14", configuration = item14Configuration),
             )
         )
     }


### PR DESCRIPTION
<img width="351" alt="Capture d’écran 2022-02-03 à 10 07 13" src="https://user-images.githubusercontent.com/26220096/152314711-68d251ce-e348-4197-adcb-b139b63caff4.png">


No need for price to be constrained to end of simpleEntryItemTitleEndOptional. It must just stick to its end barrier.
