### PR TITLE
Replace kotlin synthetics by viewBinding

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'kotlin-android-extensions'
     id 'kotlin-kapt'
     id 'maven-publish'
 }

--- a/library/src/main/java/com/spendesk/grapes/ActionMessageBottomSheetDialogFragment.kt
+++ b/library/src/main/java/com/spendesk/grapes/ActionMessageBottomSheetDialogFragment.kt
@@ -10,9 +10,9 @@ import androidx.annotation.DrawableRes
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.spendesk.grapes.databinding.FragmentBottomSheetInfoBinding
 import com.spendesk.grapes.extensions.visibleOrGone
 import com.spendesk.grapes.extensions.visibleWithTextOrGone
-import kotlinx.android.synthetic.main.fragment_bottom_sheet_info.*
 
 /**
  * @author danyboucanova
@@ -40,6 +40,7 @@ open class ActionMessageBottomSheetDialogFragment : BottomSheetDialogFragment() 
 
     // endregion Observable properties
 
+    private var binding: FragmentBottomSheetInfoBinding? = null
     override fun getTheme(): Int = R.style.BottomSheetDialogStyle // TODO: handle dark theme here.
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
@@ -61,8 +62,10 @@ open class ActionMessageBottomSheetDialogFragment : BottomSheetDialogFragment() 
         return dialog
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? =
-        inflater.inflate(R.layout.fragment_bottom_sheet_info, container, false)
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        binding = FragmentBottomSheetInfoBinding.inflate(inflater, container, false)
+        return binding?.root
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -70,18 +73,27 @@ open class ActionMessageBottomSheetDialogFragment : BottomSheetDialogFragment() 
         bindView()
     }
 
-    fun updateConfiguration(configuration: Configuration) {
-        actionMessageBottomSheetImage.setBackgroundResource(configuration.imageResourceId)
-        actionMessageBottomSheetTitleText.text = configuration.title
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding = null
+    }
 
-        actionMessageBottomSheetDescriptionText.visibleWithTextOrGone(configuration.description)
-        actionMessageBottomSheetPrimaryButton.visibleWithTextOrGone(configuration.primaryButtonText)
-        actionMessageBottomSheetSecondaryButton.visibleWithTextOrGone(configuration.secondaryButtonText)
-        actionMessageBottomSheetPullView.visibleOrGone(configuration.shouldShowHandle)
+    fun updateConfiguration(configuration: Configuration) {
+        binding?.apply {
+            actionMessageBottomSheetImage.setBackgroundResource(configuration.imageResourceId)
+            actionMessageBottomSheetTitleText.text = configuration.title
+
+            actionMessageBottomSheetDescriptionText.visibleWithTextOrGone(configuration.description)
+            actionMessageBottomSheetPrimaryButton.visibleWithTextOrGone(configuration.primaryButtonText)
+            actionMessageBottomSheetSecondaryButton.visibleWithTextOrGone(configuration.secondaryButtonText)
+            actionMessageBottomSheetPullView.visibleOrGone(configuration.shouldShowHandle)
+        }
     }
 
     private fun bindView() {
-        actionMessageBottomSheetPrimaryButton.setOnClickListener { onPrimaryButtonClicked?.invoke() }
-        actionMessageBottomSheetSecondaryButton.setOnClickListener { onSecondaryButtonClicked?.invoke() }
+        binding?.apply {
+            actionMessageBottomSheetPrimaryButton.setOnClickListener { onPrimaryButtonClicked?.invoke() }
+            actionMessageBottomSheetSecondaryButton.setOnClickListener { onSecondaryButtonClicked?.invoke() }
+        }
     }
 }

--- a/library/src/main/java/com/spendesk/grapes/DeepBlueBucketView.kt
+++ b/library/src/main/java/com/spendesk/grapes/DeepBlueBucketView.kt
@@ -2,8 +2,8 @@ package com.spendesk.grapes
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.View
-import kotlinx.android.synthetic.main.bucket_deep_blue.view.*
+import android.view.LayoutInflater
+import com.spendesk.grapes.databinding.BucketDeepBlueBinding
 
 /**
  * @author danyboucanova
@@ -27,31 +27,33 @@ open class DeepBlueBucketView : BucketView {
 
     var onButtonClick: (() -> Unit)? = null
 
-    init {
-        View.inflate(context, R.layout.bucket_deep_blue, this)
+    private val binding: BucketDeepBlueBinding = BucketDeepBlueBinding.inflate(LayoutInflater.from(context), this)
 
+    init {
         bindView()
     }
 
     fun updateData(configuration: Configuration) {
-        deepBlueBucketTitle.text = configuration.title
-        deepBlueBucketDescription.text = configuration.description
-        deepBlueBucketButton.text = configuration.buttonText
+        with(binding) {
+            deepBlueBucketTitle.text = configuration.title
+            deepBlueBucketDescription.text = configuration.description
+            deepBlueBucketButton.text = configuration.buttonText
+        }
     }
 
     fun updateTitle(title: CharSequence) {
-        deepBlueBucketTitle.text = title
+        binding.deepBlueBucketTitle.text = title
     }
 
     fun updateDescription(description: CharSequence) {
-        deepBlueBucketDescription.text = description
+        binding.deepBlueBucketDescription.text = description
     }
 
     fun updateButtonText(buttonText: CharSequence) {
-        deepBlueBucketButton.text = buttonText
+        binding.deepBlueBucketButton.text = buttonText
     }
 
     private fun bindView() {
-        deepBlueBucketButton.setOnClickListener { onButtonClick?.invoke() }
+        binding.deepBlueBucketButton.setOnClickListener { onButtonClick?.invoke() }
     }
 }

--- a/library/src/main/java/com/spendesk/grapes/InformativeActionBucketView.kt
+++ b/library/src/main/java/com/spendesk/grapes/InformativeActionBucketView.kt
@@ -2,11 +2,11 @@ package com.spendesk.grapes
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
+import com.spendesk.grapes.databinding.BucketActionInformativeBinding
 import com.spendesk.grapes.extensions.gone
 import com.spendesk.grapes.extensions.visible
 import com.spendesk.grapes.messages.MessageInlineView
-import kotlinx.android.synthetic.main.bucket_action_informative.view.*
 
 /**
  * @author danyboucanova
@@ -24,9 +24,9 @@ class InformativeActionBucketView : BucketView {
 
     var onButtonClick: (() -> Unit)? = null
 
-    init {
-        View.inflate(context, R.layout.bucket_action_informative, this)
+    private val binding: BucketActionInformativeBinding = BucketActionInformativeBinding.inflate(LayoutInflater.from(context), this)
 
+    init {
         bindView()
     }
 
@@ -39,21 +39,23 @@ class InformativeActionBucketView : BucketView {
     )
 
     fun updateData(configuration: Configuration) {
-        actionInformativeTitleText.text = configuration.title
-        actionInformativeButton.text = configuration.smallButtonText
+        with(binding) {
+            actionInformativeTitleText.text = configuration.title
+            actionInformativeButton.text = configuration.smallButtonText
 
-        if (configuration.shouldShowChip) {
-            actionInformativeMessage.visible()
-            actionInformativeSubtitleText.gone()
-            configuration.messageContent?.let { actionInformativeMessage.updateConfiguration(configuration = MessageInlineView.Configuration(it, configuration.subtitleText)) }
-        } else {
-            actionInformativeMessage.gone()
-            actionInformativeSubtitleText.visible()
-            actionInformativeSubtitleText.text = configuration.subtitleText
+            if (configuration.shouldShowChip) {
+                actionInformativeMessage.visible()
+                actionInformativeSubtitleText.gone()
+                configuration.messageContent?.let { actionInformativeMessage.updateConfiguration(configuration = MessageInlineView.Configuration(it, configuration.subtitleText)) }
+            } else {
+                actionInformativeMessage.gone()
+                actionInformativeSubtitleText.visible()
+                actionInformativeSubtitleText.text = configuration.subtitleText
+            }
         }
     }
 
     private fun bindView() {
-        actionInformativeButton.setOnClickListener { onButtonClick?.invoke() }
+        binding.actionInformativeButton.setOnClickListener { onButtonClick?.invoke() }
     }
 }

--- a/library/src/main/java/com/spendesk/grapes/RegistrationCodeView.kt
+++ b/library/src/main/java/com/spendesk/grapes/RegistrationCodeView.kt
@@ -3,12 +3,12 @@ package com.spendesk.grapes
 import android.content.Context
 import android.text.InputFilter
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import android.widget.EditText
 import androidx.cardview.widget.CardView
 import androidx.core.content.ContextCompat
 import androidx.core.widget.doAfterTextChanged
-import kotlinx.android.synthetic.main.view_registration_code.view.*
+import com.spendesk.grapes.databinding.ViewRegistrationCodeBinding
 
 /**
  * @author danyboucanova
@@ -35,9 +35,9 @@ class RegistrationCodeView : CardView {
         val thirdTextWatcher: ((String) -> Unit)
     )
 
-    init {
-        View.inflate(context, R.layout.view_registration_code, this)
+    private val binding: ViewRegistrationCodeBinding = ViewRegistrationCodeBinding.inflate(LayoutInflater.from(context), this)
 
+    init {
         setupView()
     }
 
@@ -52,8 +52,9 @@ class RegistrationCodeView : CardView {
         bindView()
     }
 
-    fun clearText() =
-        listOf(registrationCodeThirdText, registrationCodeSecondText, registrationCodeFirstText).map { it.text?.clear() }
+    fun clearText() {
+        listOf(binding.registrationCodeThirdText, binding.registrationCodeSecondText, binding.registrationCodeFirstText).forEach { it.text?.clear() }
+    }
 
     private fun setupView() {
         setCardBackgroundColor(ContextCompat.getColor(context, R.color.registrationCodeViewBackground))
@@ -62,32 +63,32 @@ class RegistrationCodeView : CardView {
 
         setOnClickListener {
             when {
-                registrationCodeFirstText.text?.length in 0 until maxCodeItemLength -> registrationCodeFirstText.requestFocus()
-                registrationCodeSecondText.text?.length in 0 until maxCodeItemLength -> registrationCodeSecondText.requestFocus()
-                registrationCodeThirdText.text?.length in 0 until maxCodeItemLength -> registrationCodeThirdText.requestFocus()
+                binding.registrationCodeFirstText.text?.length in 0 until maxCodeItemLength -> binding.registrationCodeFirstText.requestFocus()
+                binding.registrationCodeSecondText.text?.length in 0 until maxCodeItemLength -> binding.registrationCodeSecondText.requestFocus()
+                binding.registrationCodeThirdText.text?.length in 0 until maxCodeItemLength -> binding.registrationCodeThirdText.requestFocus()
             }
         }
     }
 
     private fun bindView() {
-        handleItem(registrationCodeFirstText, onFirstTextChanged) {
+        handleItem(binding.registrationCodeFirstText, onFirstTextChanged) {
             when (it.length) {
-                maxCodeItemLength -> registrationCodeSecondText.requestFocus()
+                maxCodeItemLength -> binding.registrationCodeSecondText.requestFocus()
                 else -> Unit // Nothing to do here
             }
         }
 
-        handleItem(registrationCodeSecondText, onSecondTextChanged) {
+        handleItem(binding.registrationCodeSecondText, onSecondTextChanged) {
             when (it.length) {
-                0 -> registrationCodeFirstText.requestFocus()
-                maxCodeItemLength -> registrationCodeThirdText.requestFocus()
+                0 -> binding.registrationCodeFirstText.requestFocus()
+                maxCodeItemLength -> binding.registrationCodeThirdText.requestFocus()
                 else -> Unit // Nothing to do here
             }
 
         }
-        handleItem(registrationCodeThirdText, onThirdTextChanged) {
+        handleItem(binding.registrationCodeThirdText, onThirdTextChanged) {
             when (it.length) {
-                0 -> registrationCodeSecondText.requestFocus()
+                0 -> binding.registrationCodeSecondText.requestFocus()
                 else -> Unit // Nothing to do here
             }
         }
@@ -104,7 +105,7 @@ class RegistrationCodeView : CardView {
             }
 
     private fun limitTextLength() {
-        listOf(registrationCodeFirstText, registrationCodeSecondText, registrationCodeThirdText).map {
+        listOf(binding.registrationCodeFirstText, binding.registrationCodeSecondText, binding.registrationCodeThirdText).forEach {
             it.filters = arrayOf(InputFilter.LengthFilter(maxCodeItemLength))
         }
     }

--- a/library/src/main/java/com/spendesk/grapes/UserSupplierInlineView.kt
+++ b/library/src/main/java/com/spendesk/grapes/UserSupplierInlineView.kt
@@ -4,14 +4,14 @@ import android.content.Context
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.util.TypedValue
-import android.view.View
+import android.view.LayoutInflater
 import androidx.annotation.DrawableRes
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.res.ResourcesCompat
+import com.spendesk.grapes.databinding.UserSupplierInlineViewBinding
 import com.spendesk.grapes.extensions.visibleOrGone
 import com.spendesk.grapes.extensions.visibleWithTextOrGone
 import com.spendesk.grapes.internal.libs.glide.loadFromUrl
-import kotlinx.android.synthetic.main.user_supplier_inline_view.view.*
 
 /**
  * @author Vivien Mahe
@@ -50,9 +50,7 @@ class UserSupplierInlineView : ConstraintLayout {
     private val bigImageRoundedCornerRadius = resources.getDimensionPixelOffset(R.dimen.userSupplierInlineBigImageCornerRadius)
     private val smallImageRoundedCornerRadius = resources.getDimensionPixelOffset(R.dimen.userSupplierInlineSmallImageCornerRadius)
 
-    init {
-        View.inflate(context, R.layout.user_supplier_inline_view, this)
-    }
+    private val binding: UserSupplierInlineViewBinding = UserSupplierInlineViewBinding.inflate(LayoutInflater.from(context), this)
 
     fun updateConfiguration(configuration: Configuration) {
         setTitle(configuration.title)
@@ -63,33 +61,33 @@ class UserSupplierInlineView : ConstraintLayout {
     }
 
     fun setTitle(title: CharSequence) {
-        userSupplierInlineTitleText.text = title
+        binding.userSupplierInlineTitleText.text = title
     }
 
     fun setSubtitle(subtitle: CharSequence?) {
-        userSupplierInlineSubtitleText.visibleWithTextOrGone(subtitle)
+        binding.userSupplierInlineSubtitleText.visibleWithTextOrGone(subtitle)
     }
 
     fun setBigImage(url: String?, placeholderResId: Int? = 0, shouldCircleCrop: Boolean) {
         val cornerRadius = if (shouldCircleCrop) 0 else bigImageRoundedCornerRadius
-        userSupplierInlineBigImage.loadFromUrl(url = url, errorResId = placeholderResId, shouldCircleCrop = shouldCircleCrop, roundedCorners = cornerRadius)
+        binding.userSupplierInlineBigImage.loadFromUrl(url = url, errorResId = placeholderResId, shouldCircleCrop = shouldCircleCrop, roundedCorners = cornerRadius)
     }
 
     fun setBigImageDrawable(drawable: Drawable?) {
-        userSupplierInlineBigImage.setImageDrawable(drawable)
+        binding.userSupplierInlineBigImage.setImageDrawable(drawable)
     }
 
     fun shouldShowSmallImage(shouldShowImage: Boolean) {
-        userSupplierInlineSmallImage.visibleOrGone(shouldShowImage)
+        binding.userSupplierInlineSmallImage.visibleOrGone(shouldShowImage)
     }
 
     fun setSmallImage(url: String?, placeholderResId: Int? = 0, shouldCircleCrop: Boolean) {
         val cornerRadius = if (shouldCircleCrop) 0 else smallImageRoundedCornerRadius
-        userSupplierInlineSmallImage.loadFromUrl(url = url, errorResId = placeholderResId, shouldCircleCrop = shouldCircleCrop, roundedCorners = cornerRadius)
+        binding.userSupplierInlineSmallImage.loadFromUrl(url = url, errorResId = placeholderResId, shouldCircleCrop = shouldCircleCrop, roundedCorners = cornerRadius)
     }
 
     fun setSmallImageDrawable(drawable: Drawable?) {
-        userSupplierInlineSmallImage.setImageDrawable(drawable)
+        binding.userSupplierInlineSmallImage.setImageDrawable(drawable)
     }
 
     private fun initView(attributeSet: AttributeSet?) {

--- a/library/src/main/java/com/spendesk/grapes/component/SimpleEntryItemView.kt
+++ b/library/src/main/java/com/spendesk/grapes/component/SimpleEntryItemView.kt
@@ -2,16 +2,16 @@ package com.spendesk.grapes.component
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import androidx.annotation.DrawableRes
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import com.spendesk.grapes.R
+import com.spendesk.grapes.databinding.ComponentSimpleEntryItemBinding
 import com.spendesk.grapes.extensions.*
 import com.spendesk.grapes.internal.libs.glide.loadFromUrl
 import com.spendesk.grapes.messages.MessageInlineView
-import kotlinx.android.synthetic.main.component_simple_entry_item.view.*
 
 /**
  * @author danyboucanova
@@ -55,9 +55,9 @@ class SimpleEntryItemView : ConstraintLayout {
     private val primaryImageRoundedCornerRadius = resources.getDimensionPixelOffset(R.dimen.simpleEntryItemBPrimaryImageCornerRadius)
     private val secondaryImageRoundedCornerRadius = resources.getDimensionPixelOffset(R.dimen.simpleEntryItemBSecondaryImageCornerRadius)
 
-    init {
-        View.inflate(context, R.layout.component_simple_entry_item, this)
+    private val binding: ComponentSimpleEntryItemBinding = ComponentSimpleEntryItemBinding.inflate(LayoutInflater.from(context), this)
 
+    init {
         addRippleEffect()
     }
 
@@ -66,19 +66,21 @@ class SimpleEntryItemView : ConstraintLayout {
 
         setBackgroundColor(ContextCompat.getColor(context, if (selected) R.color.simpleEntryItemBackgroundColorSelected else R.color.simpleEntryItemBackgroundColorDefault))
 
-        simpleEntryItemSelectionMarker.visibleOrInvisible(selected)
+        with(binding) {
+            simpleEntryItemSelectionMarker.visibleOrInvisible(selected)
 
-        simpleEntryItemTitleStart.isSelected = selected
-        simpleEntryItemTitleEnd.isSelected = selected
-        simpleEntryItemDescriptionStart.isSelected = selected
-        simpleEntryItemDescriptionEnd.isSelected = selected
+            simpleEntryItemTitleStart.isSelected = selected
+            simpleEntryItemTitleEnd.isSelected = selected
+            simpleEntryItemDescriptionStart.isSelected = selected
+            simpleEntryItemDescriptionEnd.isSelected = selected
+        }
     }
 
     fun updateConfiguration(configuration: Configuration) {
         configuration.primaryImageUrl
             ?.let {
-                simpleEntryItemPrimaryImage.visible()
-                simpleEntryItemPrimaryImage.loadFromUrl(
+                binding.simpleEntryItemPrimaryImage.visible()
+                binding.simpleEntryItemPrimaryImage.loadFromUrl(
                     url = configuration.primaryImageUrl,
                     errorResId = configuration.placeholderPrimaryImage,
                     shouldCircleCrop = configuration.shouldCircleCropPrimaryImage,
@@ -88,20 +90,20 @@ class SimpleEntryItemView : ConstraintLayout {
             ?: run {
                 when (configuration.placeholderPrimaryImage != ResourcesCompat.ID_NULL) {
                     true -> {
-                        simpleEntryItemPrimaryImage.visible()
-                        simpleEntryItemPrimaryImage.setImageResource(configuration.placeholderPrimaryImage)
+                        binding.simpleEntryItemPrimaryImage.visible()
+                        binding.simpleEntryItemPrimaryImage.setImageResource(configuration.placeholderPrimaryImage)
                     }
                     false -> {
-                        simpleEntryItemPrimaryImage.gone()
-                        simpleEntryItemImageAltText.visibleWithTextOrGone(configuration.imageAltText)
+                        binding.simpleEntryItemPrimaryImage.gone()
+                        binding.simpleEntryItemImageAltText.visibleWithTextOrGone(configuration.imageAltText)
                     }
                 }
             }
 
         configuration.secondaryImageUrl
             ?.let {
-                simpleEntryItemSecondaryImage.visible()
-                simpleEntryItemSecondaryImage.loadFromUrl(
+                binding.simpleEntryItemSecondaryImage.visible()
+                binding.simpleEntryItemSecondaryImage.loadFromUrl(
                     url = configuration.secondaryImageUrl,
                     errorResId = configuration.placeholderSecondaryImage,
                     shouldCircleCrop = configuration.shouldCircleCropSecondaryImage,
@@ -111,48 +113,52 @@ class SimpleEntryItemView : ConstraintLayout {
             ?: run {
                 when (configuration.placeholderSecondaryImage != ResourcesCompat.ID_NULL) {
                     true -> {
-                        simpleEntryItemSecondaryImage.visible()
-                        simpleEntryItemSecondaryImage.setImageResource(configuration.placeholderSecondaryImage)
+                        binding.simpleEntryItemSecondaryImage.visible()
+                        binding.simpleEntryItemSecondaryImage.setImageResource(configuration.placeholderSecondaryImage)
                     }
-                    false -> simpleEntryItemSecondaryImage.gone()
+                    false -> binding.simpleEntryItemSecondaryImage.gone()
                 }
             }
 
-        simpleEntryItemTitleStart.visibleWithTextOrGone(configuration.titleStart)
-        simpleEntryItemDescriptionStart.visibleWithTextOrGone(configuration.descriptionStart)
-        simpleEntryItemTitleEnd.visibleWithTextOrGone(configuration.titleEnd)
-        simpleEntryItemDescriptionEnd.visibleWithTextOrGone(configuration.descriptionEnd)
-        simpleEntryItemBadge.visibleWithTextOrGone(configuration.badgeNumber?.toString())
+        with(binding) {
+            simpleEntryItemTitleStart.visibleWithTextOrGone(configuration.titleStart)
+            simpleEntryItemDescriptionStart.visibleWithTextOrGone(configuration.descriptionStart)
+            simpleEntryItemTitleEnd.visibleWithTextOrGone(configuration.titleEnd)
+            simpleEntryItemDescriptionEnd.visibleWithTextOrGone(configuration.descriptionEnd)
+            simpleEntryItemBadge.visibleWithTextOrGone(configuration.badgeNumber?.toString())
+        }
 
         configuration.messageConfiguration
             ?.let {
-                simpleEntryItemMessage.visible()
-                simpleEntryItemMessage.updateConfiguration(configuration = it)
+                binding.simpleEntryItemMessage.visible()
+                binding.simpleEntryItemMessage.updateConfiguration(configuration = it)
             }
             ?: run {
-                simpleEntryItemMessage.gone()
+                binding.simpleEntryItemMessage.gone()
             }
 
         setGrayedOut(isGrayedOut = configuration.isGrayedOut)
         isSelected = configuration.isSelected
 
         when (configuration.titleStartDrawable != ResourcesCompat.ID_NULL) {
-            true -> simpleEntryItemTitleStart.setDrawableRight(configuration.titleStartDrawable)
-            false -> simpleEntryItemTitleStart.removeDrawables()
+            true -> binding.simpleEntryItemTitleStart.setDrawableRight(configuration.titleStartDrawable)
+            false -> binding.simpleEntryItemTitleStart.removeDrawables()
         }
 
         configuration.titleEndOptional
             ?.let {
-                simpleEntryItemTitleEndOptional.text = String.format(context.getString(R.string.simpleEntryItemTitleEndOptionalFormat), it)
-                simpleEntryItemTitleEndOptional.visible()
+                binding.simpleEntryItemTitleEndOptional.text = String.format(context.getString(R.string.simpleEntryItemTitleEndOptionalFormat), it)
+                binding.simpleEntryItemTitleEndOptional.visible()
             }
-            ?: run { simpleEntryItemTitleEndOptional.gone() }
+            ?: run { binding.simpleEntryItemTitleEndOptional.gone() }
     }
 
     fun setGrayedOut(isGrayedOut: Boolean) {
-        simpleEntryItemPrimaryImage.alpha = if (isGrayedOut) IMAGE_ALPHA_REDUCED else IMAGE_ALPHA_DEFAULT
-        simpleEntryItemSecondaryImage.alpha = if (isGrayedOut) IMAGE_ALPHA_REDUCED else IMAGE_ALPHA_DEFAULT
-        simpleEntryItemTitleStart.isEnabled = isGrayedOut.not()
-        simpleEntryItemTitleEnd.isEnabled = isGrayedOut.not()
+        with(binding) {
+            simpleEntryItemPrimaryImage.alpha = if (isGrayedOut) IMAGE_ALPHA_REDUCED else IMAGE_ALPHA_DEFAULT
+            simpleEntryItemSecondaryImage.alpha = if (isGrayedOut) IMAGE_ALPHA_REDUCED else IMAGE_ALPHA_DEFAULT
+            simpleEntryItemTitleStart.isEnabled = isGrayedOut.not()
+            simpleEntryItemTitleEnd.isEnabled = isGrayedOut.not()
+        }
     }
 }

--- a/library/src/main/java/com/spendesk/grapes/component/SimpleSectionItemView.kt
+++ b/library/src/main/java/com/spendesk/grapes/component/SimpleSectionItemView.kt
@@ -2,16 +2,16 @@ package com.spendesk.grapes.component
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import androidx.annotation.DrawableRes
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.setPadding
 import com.spendesk.grapes.R
+import com.spendesk.grapes.databinding.ComponentSimpleSectionItemBinding
 import com.spendesk.grapes.extensions.visible
 import com.spendesk.grapes.extensions.visibleWithTextOrGone
-import kotlinx.android.synthetic.main.component_simple_section_item.view.*
 
 /**
  * @author danyboucanova
@@ -59,19 +59,21 @@ class SimpleSectionItemView : ConstraintLayout {
         }
     }
 
-    init {
-        View.inflate(context, R.layout.component_simple_section_item, this)
+    private val binding: ComponentSimpleSectionItemBinding = ComponentSimpleSectionItemBinding.inflate(LayoutInflater.from(context), this)
 
+    init {
         setPadding(resources.getDimensionPixelOffset(R.dimen.listSectionItemPadding))
     }
 
     fun updateConfiguration(configuration: Configuration) {
-        if (configuration.iconStart != ResourcesCompat.ID_NULL) {
-            simpleSectionItemStartImage.visible()
-            simpleSectionItemStartImage.setBackgroundResource(configuration.iconStart)
+        with(binding) {
+            if (configuration.iconStart != ResourcesCompat.ID_NULL) {
+                simpleSectionItemStartImage.visible()
+                simpleSectionItemStartImage.setBackgroundResource(configuration.iconStart)
+            }
+            simpleSectionItemStartText.visibleWithTextOrGone(configuration.startText)
+            simpleSectionItemEndText.visibleWithTextOrGone(configuration.endText)
         }
-        simpleSectionItemStartText.visibleWithTextOrGone(configuration.startText)
-        simpleSectionItemEndText.visibleWithTextOrGone(configuration.endText)
         configuration.style?.let { setStyle(style = it) }
     }
 

--- a/library/src/main/java/com/spendesk/grapes/component/content/summary/SummaryFooterView.kt
+++ b/library/src/main/java/com/spendesk/grapes/component/content/summary/SummaryFooterView.kt
@@ -2,11 +2,10 @@ package com.spendesk.grapes.component.content.summary
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import androidx.constraintlayout.widget.ConstraintLayout
-import com.spendesk.grapes.R
+import com.spendesk.grapes.databinding.SummaryFooterBinding
 import com.spendesk.grapes.extensions.visibleWithTextOrGone
-import kotlinx.android.synthetic.main.summary_footer.view.*
 
 /**
  * @author Vivien Mahe
@@ -25,12 +24,10 @@ class SummaryFooterView : ConstraintLayout {
         val subtitle: CharSequence? = null,
     )
 
-    init {
-        View.inflate(context, R.layout.summary_footer, this)
-    }
+    private val binding: SummaryFooterBinding = SummaryFooterBinding.inflate(LayoutInflater.from(context), this)
 
     fun updateConfiguration(configuration: Configuration) {
-        summaryFooterTitle.text = configuration.title
-        summaryFooterSubtitle.visibleWithTextOrGone(configuration.subtitle)
+        binding.summaryFooterTitle.text = configuration.title
+        binding.summaryFooterSubtitle.visibleWithTextOrGone(configuration.subtitle)
     }
 }

--- a/library/src/main/java/com/spendesk/grapes/component/content/summary/SummaryHeaderView.kt
+++ b/library/src/main/java/com/spendesk/grapes/component/content/summary/SummaryHeaderView.kt
@@ -2,18 +2,18 @@ package com.spendesk.grapes.component.content.summary
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import com.spendesk.grapes.R
 import com.spendesk.grapes.UserSupplierInlineView
+import com.spendesk.grapes.databinding.SummaryHeaderBinding
 import com.spendesk.grapes.extensions.gone
 import com.spendesk.grapes.extensions.visible
 import com.spendesk.grapes.extensions.visibleOrGone
 import com.spendesk.grapes.extensions.visibleWithTextOrGone
 import com.spendesk.grapes.messages.MessageBlockView
 import com.spendesk.grapes.messages.MessageInlineView
-import kotlinx.android.synthetic.main.summary_header.view.*
 
 /**
  * @author Vivien Mahe
@@ -37,37 +37,39 @@ class SummaryHeaderView : ConstraintLayout {
         val messageBlockConfiguration: MessageBlockView.Configuration? = null
     )
 
-    init {
-        View.inflate(context, R.layout.summary_header, this)
+    private val binding: SummaryHeaderBinding = SummaryHeaderBinding.inflate(LayoutInflater.from(context), this)
 
+    init {
         setupView()
     }
 
     fun updateConfiguration(configuration: Configuration) {
-        // User & supplier
-        with(summaryHeaderExpenseAmountUserSupplier) {
-            visibleOrGone(configuration.userSupplierInlineConfiguration != null)
-            configuration.userSupplierInlineConfiguration?.let { updateConfiguration(configuration = it) }
+        with(binding) {
+            // User & supplier
+            with(summaryHeaderExpenseAmountUserSupplier) {
+                visibleOrGone(configuration.userSupplierInlineConfiguration != null)
+                configuration.userSupplierInlineConfiguration?.let { updateConfiguration(configuration = it) }
+            }
+
+            // Amount and description
+            summaryHeaderExpenseAmountTitle.text = configuration.amount
+            summaryHeaderExpenseAmountSubtitle.visibleWithTextOrGone(configuration.amountSubtitle)
+            summaryHeaderExpenseDescriptionTitle.visibleWithTextOrGone(configuration.description)
+            summaryHeaderExpenseDescriptionSubtitle.visibleWithTextOrGone(configuration.descriptionSubtitle)
+
+            // Type
+            summaryHeaderExpenseTypeMessage.updateConfiguration(configuration = configuration.typeConfiguration)
+
+            // Deny reason
+            configuration.messageBlockConfiguration
+                ?.let {
+                    summaryHeaderExpenseDenyReasonBlock.visible()
+                    summaryHeaderExpenseDenyReasonBlock.updateConfiguration(configuration = it)
+                }
+                ?: run {
+                    summaryHeaderExpenseDenyReasonBlock.gone()
+                }
         }
-
-        // Amount and description
-        summaryHeaderExpenseAmountTitle.text = configuration.amount
-        summaryHeaderExpenseAmountSubtitle.visibleWithTextOrGone(configuration.amountSubtitle)
-        summaryHeaderExpenseDescriptionTitle.visibleWithTextOrGone(configuration.description)
-        summaryHeaderExpenseDescriptionSubtitle.visibleWithTextOrGone(configuration.descriptionSubtitle)
-
-        // Type
-        summaryHeaderExpenseTypeMessage.updateConfiguration(configuration = configuration.typeConfiguration)
-
-        // Deny reason
-        configuration.messageBlockConfiguration
-            ?.let {
-                summaryHeaderExpenseDenyReasonBlock.visible()
-                summaryHeaderExpenseDenyReasonBlock.updateConfiguration(configuration = it)
-            }
-            ?: run {
-                summaryHeaderExpenseDenyReasonBlock.gone()
-            }
     }
 
     private fun setupView() {

--- a/library/src/main/java/com/spendesk/grapes/component/content/summary/block/SummaryBlockContentApproverView.kt
+++ b/library/src/main/java/com/spendesk/grapes/component/content/summary/block/SummaryBlockContentApproverView.kt
@@ -2,13 +2,12 @@ package com.spendesk.grapes.component.content.summary.block
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.View
-import com.spendesk.grapes.R
+import android.view.LayoutInflater
 import com.spendesk.grapes.component.content.summary.block.definition.SummaryBlockTitleView
 import com.spendesk.grapes.component.content.summary.block.definition.SummaryBlockView
+import com.spendesk.grapes.databinding.SummaryBlockContentApproverBinding
 import com.spendesk.grapes.list.content.summary.SummaryBlockContentAdapter
 import com.spendesk.grapes.list.content.summary.SummaryBlockContentModel
-import kotlinx.android.synthetic.main.summary_block_content_approver.view.*
 
 /**
  * @author Vivien Mahe
@@ -28,14 +27,13 @@ class SummaryBlockContentApproverView : SummaryBlockView {
     ) : SummaryBlockView.Configuration(titleConfiguration)
 
     private val adapter = SummaryBlockContentAdapter()
+    private val binding: SummaryBlockContentApproverBinding = SummaryBlockContentApproverBinding.inflate(LayoutInflater.from(context), this, true)
 
     init {
-        View.inflate(context, R.layout.summary_block_content_approver, this)
-
-        summaryBlockContentApproverList.adapter = adapter
+        binding.summaryBlockContentApproverList.adapter = adapter
     }
 
-    override fun getSummaryBlockTitleView(): SummaryBlockTitleView = summaryBlockContentApproverTitle
+    override fun getSummaryBlockTitleView(): SummaryBlockTitleView = binding.summaryBlockContentApproverTitle
 
     fun updateConfiguration(configuration: Configuration) {
         super.updateConfiguration(configuration)

--- a/library/src/main/java/com/spendesk/grapes/component/content/summary/block/SummaryBlockContentInlineView.kt
+++ b/library/src/main/java/com/spendesk/grapes/component/content/summary/block/SummaryBlockContentInlineView.kt
@@ -3,15 +3,11 @@ package com.spendesk.grapes.component.content.summary.block
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
-import android.view.View
-import com.spendesk.grapes.R
 import com.spendesk.grapes.component.content.summary.block.definition.SummaryBlockTitleView
 import com.spendesk.grapes.component.content.summary.block.definition.SummaryBlockView
-import com.spendesk.grapes.databinding.SummaryBlockContentApproverBinding
 import com.spendesk.grapes.databinding.SummaryBlockContentInlineBinding
 import com.spendesk.grapes.list.content.summary.SummaryBlockContentAdapter
 import com.spendesk.grapes.list.content.summary.SummaryBlockContentModel
-import kotlinx.android.synthetic.main.summary_block_content_inline.view.*
 
 /**
  * @author Vivien Mahe

--- a/library/src/main/java/com/spendesk/grapes/component/content/summary/block/SummaryBlockContentInlineView.kt
+++ b/library/src/main/java/com/spendesk/grapes/component/content/summary/block/SummaryBlockContentInlineView.kt
@@ -2,10 +2,13 @@ package com.spendesk.grapes.component.content.summary.block
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.LayoutInflater
 import android.view.View
 import com.spendesk.grapes.R
 import com.spendesk.grapes.component.content.summary.block.definition.SummaryBlockTitleView
 import com.spendesk.grapes.component.content.summary.block.definition.SummaryBlockView
+import com.spendesk.grapes.databinding.SummaryBlockContentApproverBinding
+import com.spendesk.grapes.databinding.SummaryBlockContentInlineBinding
 import com.spendesk.grapes.list.content.summary.SummaryBlockContentAdapter
 import com.spendesk.grapes.list.content.summary.SummaryBlockContentModel
 import kotlinx.android.synthetic.main.summary_block_content_inline.view.*
@@ -28,14 +31,13 @@ class SummaryBlockContentInlineView : SummaryBlockView {
     ) : SummaryBlockView.Configuration(titleConfiguration)
 
     private val adapter = SummaryBlockContentAdapter()
+    private val binding: SummaryBlockContentInlineBinding = SummaryBlockContentInlineBinding.inflate(LayoutInflater.from(context), this, true)
 
     init {
-        View.inflate(context, R.layout.summary_block_content_inline, this)
-
-        summaryBlockContentInlineList.adapter = adapter
+        binding.summaryBlockContentInlineList.adapter = adapter
     }
 
-    override fun getSummaryBlockTitleView(): SummaryBlockTitleView = summaryBlockContentInlineTitle
+    override fun getSummaryBlockTitleView(): SummaryBlockTitleView = binding.summaryBlockContentInlineTitle
 
     fun updateConfiguration(configuration: Configuration) {
         super.updateConfiguration(configuration)

--- a/library/src/main/java/com/spendesk/grapes/component/content/summary/block/SummaryBlockContentMapView.kt
+++ b/library/src/main/java/com/spendesk/grapes/component/content/summary/block/SummaryBlockContentMapView.kt
@@ -2,18 +2,17 @@ package com.spendesk.grapes.component.content.summary.block
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import androidx.core.view.isVisible
-import com.spendesk.grapes.R
 import com.spendesk.grapes.component.content.summary.block.definition.SummaryBlockTitleView
 import com.spendesk.grapes.component.content.summary.block.definition.SummaryBlockView
+import com.spendesk.grapes.databinding.SummaryBlockContentMapBinding
 import com.spendesk.grapes.extensions.afterMeasured
 import com.spendesk.grapes.extensions.gone
 import com.spendesk.grapes.extensions.visible
 import com.spendesk.grapes.internal.libs.glide.loadFromUrl
 import com.spendesk.grapes.list.content.summary.SummaryBlockContentAdapter
 import com.spendesk.grapes.list.content.summary.SummaryBlockContentModel
-import kotlinx.android.synthetic.main.summary_block_content_map.view.*
 
 /**
  * @author Vivien Mahe
@@ -41,17 +40,16 @@ class SummaryBlockContentMapView : SummaryBlockView {
         val buttonExpandedText: CharSequence? = null // Text appearing when the block is expanded
     ) : SummaryBlockView.Configuration(titleConfiguration)
 
+    private val binding: SummaryBlockContentMapBinding = SummaryBlockContentMapBinding.inflate(LayoutInflater.from(context), this, true)
     private val adapter = SummaryBlockContentAdapter()
     private var buttonCollapsedText: CharSequence? = null
     private var buttonExpandedText: CharSequence? = null
 
     init {
-        View.inflate(context, R.layout.summary_block_content_map, this)
-
         setupView()
     }
 
-    override fun getSummaryBlockTitleView(): SummaryBlockTitleView = summaryBlockContentMapTitle
+    override fun getSummaryBlockTitleView(): SummaryBlockTitleView = binding.summaryBlockContentMapTitle
 
     fun updateConfiguration(configuration: Configuration) {
         super.updateConfiguration(configuration)
@@ -59,50 +57,54 @@ class SummaryBlockContentMapView : SummaryBlockView {
         this.buttonCollapsedText = configuration.buttonCollapsedText
         this.buttonExpandedText = configuration.buttonExpandedText
 
-        summaryBlockContentMapDepartureTitle.text = configuration.departureAddress
-        summaryBlockContentMapArrivalTitle.text = configuration.arrivalAddress
+        with(binding) {
+            summaryBlockContentMapDepartureTitle.text = configuration.departureAddress
+            summaryBlockContentMapArrivalTitle.text = configuration.arrivalAddress
 
-        adapter.updateList(configuration.items)
+            adapter.updateList(configuration.items)
 
-        if (shouldDisplayViewMoreButton()) {
-            summaryBlockContentViewMoreButton.visible()
-            summaryBlockContentViewMoreButton.text = buttonCollapsedText
-        } else {
-            summaryBlockContentMapList.visible()
-        }
+            if (shouldDisplayViewMoreButton()) {
+                summaryBlockContentViewMoreButton.visible()
+                summaryBlockContentViewMoreButton.text = buttonCollapsedText
+            } else {
+                summaryBlockContentMapList.visible()
+            }
 
-        afterMeasured {
-            // Wait for this view to be measured, because we need the dimensions of the imageView to use with Glide.
-            with(summaryBlockContentMapImage) {
-                // Apply a ratio for the height of the image, the width is the full width of the view
-                val imageWidth = summaryBlockContentMapImage.measuredWidth
-                val imageHeight = (imageWidth.toFloat() * MAP_IMAGE_HEIGHT_RATIO).toInt()
+            afterMeasured {
+                // Wait for this view to be measured, because we need the dimensions of the imageView to use with Glide.
+                with(summaryBlockContentMapImage) {
+                    // Apply a ratio for the height of the image, the width is the full width of the view
+                    val imageWidth = measuredWidth
+                    val imageHeight = (imageWidth.toFloat() * MAP_IMAGE_HEIGHT_RATIO).toInt()
 
-                layoutParams.width = imageWidth
-                layoutParams.height = imageHeight
+                    layoutParams.width = imageWidth
+                    layoutParams.height = imageHeight
 
-                summaryBlockContentMapImage.loadFromUrl(url = configuration.mapImageUrl, size = Pair(imageWidth, imageHeight)) {
-                    // If we couldn't load the image, we just hide the imageView
-                    summaryBlockContentMapImage.gone()
+                    loadFromUrl(url = configuration.mapImageUrl, size = Pair(imageWidth, imageHeight)) {
+                        // If we couldn't load the image, we just hide the imageView
+                        gone()
+                    }
                 }
             }
         }
     }
 
     private fun setupView() {
-        summaryBlockContentMapList.gone()
-        summaryBlockContentMapList.adapter = adapter
+        with(binding) {
+            summaryBlockContentMapList.gone()
+            summaryBlockContentMapList.adapter = adapter
 
-        summaryBlockContentViewMoreButton.setOnClickListener {
-            when {
-                summaryBlockContentMapList.isVisible -> {
-                    summaryBlockContentMapList.gone()
-                    summaryBlockContentViewMoreButton.text = buttonCollapsedText
-                }
+            summaryBlockContentViewMoreButton.setOnClickListener {
+                when {
+                    summaryBlockContentMapList.isVisible -> {
+                        summaryBlockContentMapList.gone()
+                        summaryBlockContentViewMoreButton.text = buttonCollapsedText
+                    }
 
-                summaryBlockContentMapList.isVisible.not() -> {
-                    summaryBlockContentMapList.visible()
-                    summaryBlockContentViewMoreButton.text = buttonExpandedText
+                    summaryBlockContentMapList.isVisible.not() -> {
+                        summaryBlockContentMapList.visible()
+                        summaryBlockContentViewMoreButton.text = buttonExpandedText
+                    }
                 }
             }
         }

--- a/library/src/main/java/com/spendesk/grapes/component/content/summary/block/SummaryBlockContentResponsibilityCenterGaugeLegendView.kt
+++ b/library/src/main/java/com/spendesk/grapes/component/content/summary/block/SummaryBlockContentResponsibilityCenterGaugeLegendView.kt
@@ -2,11 +2,10 @@ package com.spendesk.grapes.component.content.summary.block
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.res.ResourcesCompat
-import com.spendesk.grapes.R
-import kotlinx.android.synthetic.main.view_responsibility_center_gauge_legend.view.*
+import com.spendesk.grapes.databinding.ViewResponsibilityCenterGaugeLegendBinding
 
 /**
  * @author danyboucanova
@@ -26,13 +25,13 @@ class SummaryBlockContentResponsibilityCenterGaugeLegendView : ConstraintLayout 
         val resourceId: Int = ResourcesCompat.ID_NULL
     )
 
-    init {
-        View.inflate(context, R.layout.view_responsibility_center_gauge_legend, this)
-    }
+    private val binding: ViewResponsibilityCenterGaugeLegendBinding = ViewResponsibilityCenterGaugeLegendBinding.inflate(LayoutInflater.from(context), this, true)
 
     fun updateConfiguration(configuration: Configuration) {
-        responsibilityCenterGaugeLegendImage.setBackgroundResource(configuration.resourceId)
-        responsibilityCenterGaugeLegendTitle.text = configuration.title
-        responsibilityCenterGaugeLegendSubtitle.text = configuration.subtitle
+        with(binding) {
+            responsibilityCenterGaugeLegendImage.setBackgroundResource(configuration.resourceId)
+            responsibilityCenterGaugeLegendTitle.text = configuration.title
+            responsibilityCenterGaugeLegendSubtitle.text = configuration.subtitle
+        }
     }
 }

--- a/library/src/main/java/com/spendesk/grapes/component/content/summary/block/SummaryBlockContentResponsibilityCenterGaugeView.kt
+++ b/library/src/main/java/com/spendesk/grapes/component/content/summary/block/SummaryBlockContentResponsibilityCenterGaugeView.kt
@@ -2,15 +2,17 @@ package com.spendesk.grapes.component.content.summary.block
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.LayoutInflater
 import android.view.View
 import androidx.annotation.DrawableRes
 import androidx.annotation.FloatRange
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.res.ResourcesCompat
 import com.spendesk.grapes.R
+import com.spendesk.grapes.databinding.SummaryBlockContentMapBinding
+import com.spendesk.grapes.databinding.ViewResponsibilityCenterGaugeBinding
 import com.spendesk.grapes.extensions.setDrawable
 import com.spendesk.grapes.extensions.visible
-import kotlinx.android.synthetic.main.view_responsibility_center_gauge.view.*
 
 /**
  * @author danyboucanova
@@ -38,30 +40,29 @@ class SummaryBlockContentResponsibilityCenterGaugeView : ConstraintLayout {
         @FloatRange(from = 0.0, to = 1.0) val ratio: Float
     )
 
-    init {
-        View.inflate(context, R.layout.view_responsibility_center_gauge, this)
-    }
+    private val binding: ViewResponsibilityCenterGaugeBinding = ViewResponsibilityCenterGaugeBinding.inflate(LayoutInflater.from(context), this)
 
     fun updateConfiguration(configuration: Configuration) {
         if (configuration.gauges.size > MAX_GAUGES) {
             throw IllegalArgumentException("Error: Too many gauges (size: ${configuration.gauges.size}) given in argument. This view cannot handle more than: $MAX_GAUGES gauges.")
         }
+        with(binding) {
+            val gaugeViews = listOf(responsibilityCenterGaugePrimaryView, responsibilityCenterGaugeSecondaryView, responsibilityCenterGaugeTertiaryView)
+            val guidelineViews = listOf(responsibilityCenterGaugePrimaryGuideline, responsibilityCenterGaugeSecondaryGuideline, responsibilityCenterGaugeTertiaryGuideline)
 
-        val gaugeViews = listOf(responsibilityCenterGaugePrimaryView, responsibilityCenterGaugeSecondaryView, responsibilityCenterGaugeTertiaryView)
-        val guidelineViews = listOf(responsibilityCenterGaugePrimaryGuideline, responsibilityCenterGaugeSecondaryGuideline, responsibilityCenterGaugeTertiaryGuideline)
+            // Handle Gauges
+            configuration.gauges.forEachIndexed { index, gauge ->
+                gaugeViews[index].visible()
+                gaugeViews[index].setBackgroundResource(gauge.resourceId)
+                guidelineViews[index].setGuidelinePercent(gauge.ratio)
+            }
 
-        // Handle Gauges
-        configuration.gauges.forEachIndexed { index, gauge ->
-            gaugeViews[index].visible()
-            gaugeViews[index].setBackgroundResource(gauge.resourceId)
-            guidelineViews[index].setGuidelinePercent(gauge.ratio)
-        }
-
-        // Handle Threshold
-        configuration.threshold?.let {
-            responsibilityCenterGaugeLimitView.visible()
-            responsibilityCenterGaugeLimitGuideline.setGuidelinePercent(it)
-            responsibilityCenterGaugeLimitView.setDrawable(colorId = R.color.responsibilityCenterGaugeViewLimitBackground, radiusId = R.dimen.responsibilityCenterGaugeLimitRadius)
+            // Handle Threshold
+            configuration.threshold?.let {
+                responsibilityCenterGaugeLimitView.visible()
+                responsibilityCenterGaugeLimitGuideline.setGuidelinePercent(it)
+                responsibilityCenterGaugeLimitView.setDrawable(colorId = R.color.responsibilityCenterGaugeViewLimitBackground, radiusId = R.dimen.responsibilityCenterGaugeLimitRadius)
+            }
         }
     }
 }

--- a/library/src/main/java/com/spendesk/grapes/component/content/summary/block/SummaryBlockContentResponsibilityCenterView.kt
+++ b/library/src/main/java/com/spendesk/grapes/component/content/summary/block/SummaryBlockContentResponsibilityCenterView.kt
@@ -2,13 +2,12 @@ package com.spendesk.grapes.component.content.summary.block
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.View
-import com.spendesk.grapes.R
+import android.view.LayoutInflater
+import com.spendesk.grapes.component.content.summary.block.SummaryBlockContentResponsibilityCenterGaugeView.Constants.MAX_GAUGES
 import com.spendesk.grapes.component.content.summary.block.definition.SummaryBlockTitleView
 import com.spendesk.grapes.component.content.summary.block.definition.SummaryBlockView
-import com.spendesk.grapes.component.content.summary.block.SummaryBlockContentResponsibilityCenterGaugeView.Constants.MAX_GAUGES
+import com.spendesk.grapes.databinding.SummaryBlockContentResponsibilityCenterBinding
 import com.spendesk.grapes.extensions.visibleOrGone
-import kotlinx.android.synthetic.main.summary_block_content_responsibility_center.view.*
 
 /**
  * @author danyboucanova
@@ -34,27 +33,24 @@ class SummaryBlockContentResponsibilityCenterView : SummaryBlockView {
         val showLegend: Boolean = false
     ) : SummaryBlockView.Configuration(titleConfiguration)
 
-    init {
-        View.inflate(context, R.layout.summary_block_content_responsibility_center, this)
-    }
+    private val binding: SummaryBlockContentResponsibilityCenterBinding = SummaryBlockContentResponsibilityCenterBinding.inflate(LayoutInflater.from(context), this, true)
 
-    override fun getSummaryBlockTitleView(): SummaryBlockTitleView = summaryBlockContentResponsibilityCenterTitle
+    override fun getSummaryBlockTitleView(): SummaryBlockTitleView = binding.summaryBlockContentResponsibilityCenterTitle
 
     fun updateConfiguration(configuration: Configuration) {
         super.updateConfiguration(configuration)
 
-        summaryBlockContentResponsibilityCenterDescription.text = configuration.description
+        binding.summaryBlockContentResponsibilityCenterDescription.text = configuration.description
 
         // Handle Gauges
-        summaryBlockContentResponsibilityCenterGaugeView.updateConfiguration(configuration.gaugeViewConfiguration)
+        binding.summaryBlockContentResponsibilityCenterGaugeView.updateConfiguration(configuration.gaugeViewConfiguration)
 
         // Handle Legend
         showLegend(configuration.showLegend)
         handleLegend(configuration.legendConfiguration)
     }
 
-    fun showLegend(visibility: Boolean) =
-        summaryBlockContentResponsibilityCenterLegendFlow.visibleOrGone(visibility)
+    fun showLegend(visibility: Boolean) = binding.summaryBlockContentResponsibilityCenterLegendFlow.visibleOrGone(visibility)
 
     private fun handleLegend(legendConfiguration: List<SummaryBlockContentResponsibilityCenterGaugeLegendView.Configuration>) {
         if (legendConfiguration.size > MAX_LEGENDS) {
@@ -62,12 +58,14 @@ class SummaryBlockContentResponsibilityCenterView : SummaryBlockView {
         }
 
         // Configure each legend
-        val legendViews =
-            listOf(summaryBlockContentResponsibilityCenterLegendFlowPrimary, summaryBlockContentResponsibilityCenterLegendFlowSecondary, summaryBlockContentResponsibilityCenterLegendFlowTertiary)
+        with(binding) {
+            val legendViews =
+                listOf(summaryBlockContentResponsibilityCenterLegendFlowPrimary, summaryBlockContentResponsibilityCenterLegendFlowSecondary, summaryBlockContentResponsibilityCenterLegendFlowTertiary)
 
-        legendConfiguration.forEachIndexed { index, legend ->
-            summaryBlockContentResponsibilityCenterLegendFlow.referencedIds += legendViews[index].id
-            legendViews[index].updateConfiguration(legend)
+            legendConfiguration.forEachIndexed { index, legend ->
+                summaryBlockContentResponsibilityCenterLegendFlow.referencedIds += legendViews[index].id
+                legendViews[index].updateConfiguration(legend)
+            }
         }
     }
 }

--- a/library/src/main/java/com/spendesk/grapes/inputs/InputSearchMain.kt
+++ b/library/src/main/java/com/spendesk/grapes/inputs/InputSearchMain.kt
@@ -4,16 +4,15 @@ import android.content.Context
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import androidx.appcompat.widget.AppCompatEditText
 import androidx.cardview.widget.CardView
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import com.spendesk.grapes.R
+import com.spendesk.grapes.databinding.InputSearchMainBinding
 import com.spendesk.grapes.extensions.setupClearButtonWithAction
 import com.spendesk.grapes.extensions.visibleOrInvisible
-import kotlinx.android.synthetic.main.input_search_main.view.*
-import java.util.*
 
 /**
  * @author danyboucanova
@@ -54,9 +53,7 @@ class InputSearchMain : CardView {
         }
     }
 
-    init {
-        View.inflate(context, R.layout.input_search_main, this)
-    }
+    private val binding: InputSearchMainBinding = InputSearchMainBinding.inflate(LayoutInflater.from(context), this, true)
 
     fun setStyle(style: Style) {
         when (style) {
@@ -73,10 +70,9 @@ class InputSearchMain : CardView {
         }
     }
 
-    fun showProgressBar(visible: Boolean) =
-        inputSearchMainProgressBar.visibleOrInvisible(visible)
+    fun showProgressBar(visible: Boolean) = binding.inputSearchMainProgressBar.visibleOrInvisible(visible)
 
-    fun getEditText(): AppCompatEditText = inputSearchMainEditText
+    fun getEditText(): AppCompatEditText = binding.inputSearchMainEditText
 
     private fun setupView(attributeSet: AttributeSet?) {
         attributeSet?.let {
@@ -96,7 +92,7 @@ class InputSearchMain : CardView {
     }
 
     private fun configureEditText(focusable: Boolean, hint: Int, drawableStart: Int, style: Style, shouldUseClearButton: Boolean) {
-        with(inputSearchMainEditText) {
+        with(binding.inputSearchMainEditText) {
 
             // set basic properties
             isFocusable = focusable

--- a/library/src/main/java/com/spendesk/grapes/list/content/summary/item/ApproverStatusItemView.kt
+++ b/library/src/main/java/com/spendesk/grapes/list/content/summary/item/ApproverStatusItemView.kt
@@ -2,14 +2,13 @@ package com.spendesk.grapes.list.content.summary.item
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import androidx.annotation.DrawableRes
 import androidx.constraintlayout.widget.ConstraintLayout
-import com.spendesk.grapes.R
+import com.spendesk.grapes.databinding.ItemApproverStatusBinding
 import com.spendesk.grapes.extensions.visibleWithTextOrGone
 import com.spendesk.grapes.internal.libs.glide.loadFromUrl
 import com.spendesk.grapes.messages.MessageInlineView
-import kotlinx.android.synthetic.main.item_approver_status.view.*
 
 /**
  * @author danyboucanova
@@ -31,15 +30,15 @@ class ApproverStatusItemView : ConstraintLayout {
         val messageInlineStatusStyle: MessageInlineView.Style? = null
     )
 
-    init {
-        View.inflate(context, R.layout.item_approver_status, this)
-    }
+    private val binding: ItemApproverStatusBinding = ItemApproverStatusBinding.inflate(LayoutInflater.from(context), this, true)
 
     fun updateConfiguration(configuration: Configuration) {
-        itemApproverStatusText.text = configuration.title
-        itemApproverStatusImage.loadFromUrl(url = configuration.imageUrl, errorResId = configuration.placeholderResId, shouldCircleCrop = true)
+        with(binding) {
+            itemApproverStatusText.text = configuration.title
+            itemApproverStatusImage.loadFromUrl(url = configuration.imageUrl, errorResId = configuration.placeholderResId, shouldCircleCrop = true)
 
-        itemApproverStatusMessageInline.visibleWithTextOrGone(configuration.messageInlineStatusText)
-        configuration.messageInlineStatusStyle?.let { itemApproverStatusMessageInline.setStyle(it) }
+            itemApproverStatusMessageInline.visibleWithTextOrGone(configuration.messageInlineStatusText)
+            configuration.messageInlineStatusStyle?.let { itemApproverStatusMessageInline.setStyle(it) }
+        }
     }
 }

--- a/library/src/main/java/com/spendesk/grapes/list/content/summary/item/InlineKeyValueItemView.kt
+++ b/library/src/main/java/com/spendesk/grapes/list/content/summary/item/InlineKeyValueItemView.kt
@@ -2,10 +2,11 @@ package com.spendesk.grapes.list.content.summary.item
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.LayoutInflater
 import android.view.View
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.spendesk.grapes.R
-import kotlinx.android.synthetic.main.item_inline_key_value.view.*
+import com.spendesk.grapes.databinding.ItemInlineKeyValueBinding
 
 /**
  * @author danyboucanova
@@ -26,12 +27,16 @@ class InlineKeyValueItemView : ConstraintLayout {
         val value: CharSequence
     )
 
+    private val binding: ItemInlineKeyValueBinding = ItemInlineKeyValueBinding.inflate(LayoutInflater.from(context), this, true)
+
     init {
         View.inflate(context, R.layout.item_inline_key_value, this)
     }
 
     fun updateConfiguration(configuration: Configuration) {
-        inlineBlockViewKeyText.text = configuration.key
-        inlineBlockViewValueText.text = configuration.value
+        with(binding) {
+            inlineBlockViewKeyText.text = configuration.key
+            inlineBlockViewValueText.text = configuration.value
+        }
     }
 }

--- a/library/src/main/java/com/spendesk/grapes/messages/MessageBlockView.kt
+++ b/library/src/main/java/com/spendesk/grapes/messages/MessageBlockView.kt
@@ -5,7 +5,7 @@ import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.util.TypedValue
-import android.view.View
+import android.view.LayoutInflater
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -14,9 +14,9 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.graphics.drawable.toDrawable
 import com.spendesk.grapes.R
+import com.spendesk.grapes.databinding.MessageBlockViewBinding
 import com.spendesk.grapes.extensions.*
 import com.spendesk.grapes.internal.libs.glide.loadFromUrl
-import kotlinx.android.synthetic.main.message_block_view.view.*
 
 
 /**
@@ -41,9 +41,9 @@ class MessageBlockView : ConstraintLayout {
 
     //endregion constructors
 
-    init {
-        View.inflate(context, R.layout.message_block_view, this)
+    private val binding: MessageBlockViewBinding = MessageBlockViewBinding.inflate(LayoutInflater.from(context), this)
 
+    init {
         setupView()
     }
 
@@ -88,7 +88,7 @@ class MessageBlockView : ConstraintLayout {
         setSignatureText(configuration.signatureText)
         configuration.signatureText
             ?.let { setSignatureDrawable(url = configuration.signatureDrawableUrl, placeholderResId = configuration.signatureDrawablePlaceholderResId) }
-            ?: run { messageBlockSignatureImage.gone() }
+            ?: run { binding.messageBlockSignatureImage.gone() }
     }
 
     /**
@@ -104,13 +104,13 @@ class MessageBlockView : ConstraintLayout {
             Style.WARNING -> ColorConfiguration(R.color.mainWarningNormal, R.color.mainWarningLightest, R.color.mainWarningLighter)
             Style.INFO -> ColorConfiguration(R.color.mainInfoNormal, R.color.mainInfoLightest, R.color.mainInfoLighter)
         }.let { configuration ->
-            messageBlockTitle.setTextColor(ContextCompat.getColor(context, configuration.textColor))
+            binding.messageBlockTitle.setTextColor(ContextCompat.getColor(context, configuration.textColor))
             setDrawable(colorId = configuration.backgroundColor, radiusId = R.dimen.messageInlineRadius, strokeSizeId = R.dimen.messageInlineStrokeSize, strokeColorId = configuration.strokeColor)
         }
     }
 
     fun setTitle(title: CharSequence) {
-        messageBlockTitle.text = title
+        binding.messageBlockTitle.text = title
     }
 
     fun setTitleDrawable(drawableStartId: Int) {
@@ -119,29 +119,31 @@ class MessageBlockView : ConstraintLayout {
             // Convert drawable to a bitmap sized accordingly to be set as drawableStart in the textView.
             // The Bitmap is then converted again to a drawable but now having the right size which will not push the bounds and the size of the whole view.
             val drawableBitmap = ContextCompat.getDrawable(context, drawableStartId)?.toBitmap(drawableSize, drawableSize)
-            messageBlockTitle.setDrawableLeft(drawableBitmap?.toDrawable(resources))
+            binding.messageBlockTitle.setDrawableLeft(drawableBitmap?.toDrawable(resources))
         }
     }
 
     fun setDescription(description: CharSequence?) {
-        messageBlockDescription.visibleWithTextOrGone(description)
+        binding.messageBlockDescription.visibleWithTextOrGone(description)
     }
 
     fun setSignatureText(signatureText: CharSequence?) {
-        messageBlockSignatureText.visibleWithTextOrGone(signatureText)
+        binding.messageBlockSignatureText.visibleWithTextOrGone(signatureText)
     }
 
     fun setSignatureDrawable(url: String?, placeholderResId: Int? = 0) {
-        if (url != null || placeholderResId != null) {
-            messageBlockSignatureImage.visible()
-            messageBlockSignatureImage.loadFromUrl(url = url, errorResId = placeholderResId, shouldCircleCrop = true)
-        } else {
-            messageBlockSignatureImage.gone()
+        with(binding.messageBlockSignatureImage) {
+            if (url != null || placeholderResId != null) {
+                visible()
+                loadFromUrl(url = url, errorResId = placeholderResId, shouldCircleCrop = true)
+            } else {
+                gone()
+            }
         }
     }
 
     fun setSignatureDrawable(drawable: Drawable?) {
-        drawable?.let { messageBlockSignatureImage.setImageDrawable(it) }
+        drawable?.let { binding.messageBlockSignatureImage.setImageDrawable(it) }
     }
 
     private fun initView(attributeSet: AttributeSet?) {
@@ -166,7 +168,7 @@ class MessageBlockView : ConstraintLayout {
     }
 
     private fun setupView() {
-        if (isInEditMode.not()) messageBlockTitle.setTypeface(ResourcesCompat.getFont(context, R.font.gt_america_bold), Typeface.NORMAL)
+        if (isInEditMode.not()) binding.messageBlockTitle.setTypeface(ResourcesCompat.getFont(context, R.font.gt_america_bold), Typeface.NORMAL)
 
         val paddingVert = resources.getDimensionPixelOffset(R.dimen.messageBlockPaddingVert)
         val paddingHorz = resources.getDimensionPixelOffset(R.dimen.messageBlockPaddingHorz)

--- a/library/src/main/java/com/spendesk/grapes/selectors/HeaderStatusIndicator.kt
+++ b/library/src/main/java/com/spendesk/grapes/selectors/HeaderStatusIndicator.kt
@@ -7,7 +7,7 @@ import android.animation.TimeInterpolator
 import android.content.Context
 import android.transition.TransitionManager
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.view.animation.LinearInterpolator
 import android.widget.ProgressBar
@@ -15,7 +15,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.interpolator.view.animation.FastOutSlowInInterpolator
 import com.spendesk.grapes.R
-import kotlinx.android.synthetic.main.selectors_header_status_indicator.view.*
+import com.spendesk.grapes.databinding.SelectorsHeaderStatusIndicatorBinding
 import kotlin.math.abs
 
 /**
@@ -44,9 +44,9 @@ class HeaderStatusIndicator : ConstraintLayout {
     private var animatorSet: AnimatorSet? = null
     private var currentIndex: Int = 0
 
-    init {
-        View.inflate(context, R.layout.selectors_header_status_indicator, this)
+    private val binding: SelectorsHeaderStatusIndicatorBinding = SelectorsHeaderStatusIndicatorBinding.inflate(LayoutInflater.from(context), this)
 
+    init {
         setBackgroundColor(ContextCompat.getColor(context, R.color.headerStatusIndicatorBackgroundColor))
     }
 
@@ -66,7 +66,7 @@ class HeaderStatusIndicator : ConstraintLayout {
             }
         }
 
-        selectorsHeaderStatusIndicatorFlow.referencedIds = progressBarIds.toIntArray()
+        binding.selectorsHeaderStatusIndicatorFlow.referencedIds = progressBarIds.toIntArray()
     }
 
     private fun addProgressBars(amountOfProgressBarToAdd: Int) {
@@ -89,7 +89,7 @@ class HeaderStatusIndicator : ConstraintLayout {
         for (i in progressBarIds.size - 1 downTo progressBarIds.size - amountOfProgressBarToRemove) {
             val progressBarId = progressBarIds[i]
             val progressBar = findViewById<ProgressBar>(progressBarId)
-            selectorsHeaderStatusIndicatorFlow.removeView(progressBar)
+            binding.selectorsHeaderStatusIndicatorFlow.removeView(progressBar)
             progressBarIds.remove(progressBarId)
             removeView(progressBar)
         }

--- a/library/src/main/java/com/spendesk/grapes/selectors/PickerBlockIconCardView.kt
+++ b/library/src/main/java/com/spendesk/grapes/selectors/PickerBlockIconCardView.kt
@@ -2,11 +2,11 @@ package com.spendesk.grapes.selectors
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
 import com.spendesk.grapes.R
-import kotlinx.android.synthetic.main.selector_picker_block_icon.view.*
+import com.spendesk.grapes.databinding.SelectorPickerBlockIconBinding
 
 /**
  * @author danyboucanova
@@ -27,9 +27,9 @@ class PickerBlockIconCardView : SelectBlockCardView {
         @DrawableRes val icon: Int
     )
 
-    init {
-        View.inflate(context, R.layout.selector_picker_block_icon, this)
+    private val binding: SelectorPickerBlockIconBinding = SelectorPickerBlockIconBinding.inflate(LayoutInflater.from(context), this)
 
+    init {
         isClickable = true
         isFocusable = true
 
@@ -40,9 +40,11 @@ class PickerBlockIconCardView : SelectBlockCardView {
     fun updateConfiguration(configuration: Configuration) {
         isChecked = configuration.isSelected
 
-        pickerBlockIconImageView.setImageResource(configuration.icon)
-        pickerBlockIconImageView.setColorFilter(
-            ContextCompat.getColor(context, if (configuration.isSelected) R.color.pickerBlockIconCardViewIconSelectedTint else R.color.pickerBlockIconCardViewIconUnselectedTint)
-        )
+        with(binding.pickerBlockIconImageView) {
+            setImageResource(configuration.icon)
+            setColorFilter(
+                ContextCompat.getColor(context, if (configuration.isSelected) R.color.pickerBlockIconCardViewIconSelectedTint else R.color.pickerBlockIconCardViewIconUnselectedTint)
+            )
+        }
     }
 }

--- a/library/src/main/java/com/spendesk/grapes/selectors/SwitchCardView.kt
+++ b/library/src/main/java/com/spendesk/grapes/selectors/SwitchCardView.kt
@@ -2,10 +2,10 @@ package com.spendesk.grapes.selectors
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import androidx.cardview.widget.CardView
 import com.spendesk.grapes.R
-import kotlinx.android.synthetic.main.selector_switch_card.view.*
+import com.spendesk.grapes.databinding.SelectorSwitchCardBinding
 
 /**
  * @author danyboucanova
@@ -28,18 +28,18 @@ class SwitchCardView : CardView {
         val isChecked: Boolean = false
     )
 
-    init {
-        View.inflate(context, R.layout.selector_switch_card, this)
+    private val binding: SelectorSwitchCardBinding = SelectorSwitchCardBinding.inflate(LayoutInflater.from(context), this)
 
+    init {
         radius = resources.getDimensionPixelOffset(R.dimen.switchCardRadius).toFloat()
         elevation = resources.getDimensionPixelOffset(R.dimen.switchCardElevation).toFloat()
 
-        setOnClickListener { switchCardSwitch.isChecked = !switchCardSwitch.isChecked }
-        switchCardSwitch.setOnCheckedChangeListener { _, isChecked -> onChecked?.invoke(isChecked) }
+        setOnClickListener { binding.switchCardSwitch.isChecked = !binding.switchCardSwitch.isChecked }
+        binding.switchCardSwitch.setOnCheckedChangeListener { _, isChecked -> onChecked?.invoke(isChecked) }
     }
 
     fun updateConfiguration(configuration: Configuration) {
-        switchCardSwitch.isChecked = configuration.isChecked
-        switchCardText.text = configuration.text
+        binding.switchCardSwitch.isChecked = configuration.isChecked
+        binding.switchCardText.text = configuration.text
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -20,6 +20,10 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    buildFeatures {
+        viewBinding = true
+    }
+
     signingConfigs {
         release {
             storeFile file("spendesk-grapes.keystore")

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
     id 'kotlin-kapt'
-    id 'kotlin-android-extensions'
+    id 'kotlin-parcelize'
     id 'dagger.hilt.android.plugin'
     id 'com.google.firebase.appdistribution'
 }

--- a/sample/src/main/java/com/spendesk/grapes/samples/core/internal/FragmentViewBindingDelegates.kt
+++ b/sample/src/main/java/com/spendesk/grapes/samples/core/internal/FragmentViewBindingDelegates.kt
@@ -1,0 +1,51 @@
+package com.spendesk.grapes.samples.core.internal
+
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.viewbinding.ViewBinding
+import com.spendesk.grapes.samples.R
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+/**
+ * Delegates a viewBinding read-only property storing it inside the bind view's tag.
+ *
+ * usage:
+ * ```
+ *  class ExampleFragment : Fragment {
+ *      //...
+ *      private val binding: ExampleFragmentBinding by viewBinding(ExampleFragmentBinding::bind)
+ *      // ...
+ *  }
+ * ```
+ *
+ * @param ViewBindingT the [ViewBinding] property type.
+ * @param bind You need to call [ViewBindingT].bind static method to bind the view binding
+ *  to fragment's view.
+ * @return a [ViewBindingT] delegates
+ *
+ */
+fun <ViewBindingT : ViewBinding> viewBinding(
+    bind: (View) -> ViewBindingT
+): ReadOnlyProperty<Fragment, ViewBindingT> {
+    return FragmentViewBindingDelegate(bind)
+}
+
+private class FragmentViewBindingDelegate<out ViewBindingT : ViewBinding>(
+    private val bind: (View) -> ViewBindingT
+) : ReadOnlyProperty<Fragment, ViewBindingT> {
+    override fun getValue(thisRef: Fragment, property: KProperty<*>): ViewBindingT {
+        return thisRef.requireView().getOrPutBinding(R.id.view_binding_tag)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun View.getOrPutBinding(key: Int): ViewBindingT {
+        val binding = getTag(key) as? ViewBindingT
+        if (binding == null) {
+            val newBinding = bind(this)
+            setTag(key, newBinding)
+            return newBinding
+        }
+        return binding
+    }
+}

--- a/sample/src/main/java/com/spendesk/grapes/samples/entity/HomeTabItem.kt
+++ b/sample/src/main/java/com/spendesk/grapes/samples/entity/HomeTabItem.kt
@@ -1,7 +1,7 @@
 package com.spendesk.grapes.samples.entity
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 /**
  * @author danyboucanova

--- a/sample/src/main/java/com/spendesk/grapes/samples/home/HomeActivity.kt
+++ b/sample/src/main/java/com/spendesk/grapes/samples/home/HomeActivity.kt
@@ -10,27 +10,31 @@ import com.google.android.material.tabs.TabLayoutMediator
 import com.spendesk.grapes.samples.R
 import com.spendesk.grapes.samples.core.extensions.disposedBy
 import com.spendesk.grapes.samples.core.extensions.isDarkThemeOn
+import com.spendesk.grapes.samples.databinding.ActivityHomeBinding
 import com.spendesk.grapes.samples.entity.HomeTabItem
 import dagger.hilt.android.AndroidEntryPoint
 import io.reactivex.rxjava3.disposables.CompositeDisposable
-import kotlinx.android.synthetic.main.activity_home.*
 
 /**
  * @author danyboucanova
  * @since 1/4/21
  */
 @AndroidEntryPoint
-class HomeActivity : AppCompatActivity(R.layout.activity_home) {
+class HomeActivity : AppCompatActivity() {
 
     private val viewModel: HomeActivityViewModel by viewModels()
 
     private val disposables = CompositeDisposable()
     private lateinit var homeAdapter: HomePagerAdapter
+    private lateinit var binding: ActivityHomeBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        setSupportActionBar(homeToolbar)
+        binding = ActivityHomeBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        setSupportActionBar(binding.homeToolbar)
 
         setupView()
         bindViewModel()
@@ -60,15 +64,16 @@ class HomeActivity : AppCompatActivity(R.layout.activity_home) {
 
     private fun setupView() {
         homeAdapter = HomePagerAdapter(this)
-        homeViewPager.adapter = homeAdapter
-        homeViewPager.isUserInputEnabled = false
-
+        with(binding.homeViewPager) {
+            adapter = homeAdapter
+            isUserInputEnabled = false
+        }
     }
 
     private fun updateHomeTabs(expenseItemList: List<HomeTabItem>) {
         homeAdapter.updateList(expenseItemList)
 
-        TabLayoutMediator(homeTabLayout, homeViewPager, true) { tab, position ->
+        TabLayoutMediator(binding.homeTabLayout, binding.homeViewPager, true) { tab, position ->
             tab.text = homeAdapter.getTabText(position)
         }.attach()
     }

--- a/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/BottomSheetsFragment.kt
+++ b/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/BottomSheetsFragment.kt
@@ -11,8 +11,8 @@ import com.spendesk.grapes.extensions.empty
 import com.spendesk.grapes.extensions.shortToaster
 import com.spendesk.grapes.list.simple.SimpleListModel
 import com.spendesk.grapes.samples.R
-import kotlinx.android.synthetic.main.fragment_home_bottom_sheets.*
-import kotlinx.android.synthetic.main.view_home_header.*
+import com.spendesk.grapes.samples.core.internal.viewBinding
+import com.spendesk.grapes.samples.databinding.FragmentHomeBottomSheetsBinding
 
 /**
  * @author Vivien Mahe
@@ -24,17 +24,19 @@ class BottomSheetsFragment : Fragment(R.layout.fragment_home_bottom_sheets) {
         fun newInstance() = BottomSheetsFragment()
     }
 
+    private val binding by viewBinding(FragmentHomeBottomSheetsBinding::bind)
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        homeGenericHeaderTitle.text = context?.getString(R.string.bottomSheets)
+        binding.homeHeader.homeGenericHeaderTitle.text = context?.getString(R.string.bottomSheets)
 
         setupView()
     }
 
     private fun setupView() {
         // Searchable with ViewState.Content
-        homeBottomSheetsSectionSearchableContentButton.setOnClickListener {
+        binding.homeBottomSheetsSectionSearchableContentButton.setOnClickListener {
             val sectionConfiguration = SimpleSectionItemView.Configuration(
                 startText = "This is a secondary section",
                 style = SimpleSectionItemView.Style.SECONDARY
@@ -62,7 +64,7 @@ class BottomSheetsFragment : Fragment(R.layout.fragment_home_bottom_sheets) {
         }
 
         // Searchable with ViewState.Empty
-        homeBottomSheetsSectionSearchableEmptyButton.setOnClickListener {
+        binding.homeBottomSheetsSectionSearchableEmptyButton.setOnClickListener {
             createSearchableBottomSheetFragment().apply {
                 updateViewState(
                     viewState = SearchableBottomSheetDialogFragmentViewState.Empty(

--- a/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/ButtonsFragment.kt
+++ b/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/ButtonsFragment.kt
@@ -4,7 +4,8 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
 import com.spendesk.grapes.samples.R
-import kotlinx.android.synthetic.main.view_home_header.*
+import com.spendesk.grapes.samples.core.internal.viewBinding
+import com.spendesk.grapes.samples.databinding.FragmentHomeButtonsBinding
 
 /**
  * @author danyboucanova
@@ -16,9 +17,11 @@ class ButtonsFragment : Fragment(R.layout.fragment_home_buttons) {
         fun newInstance() = ButtonsFragment()
     }
 
+    private val binding by viewBinding(FragmentHomeButtonsBinding::bind)
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        homeGenericHeaderTitle.text = context?.getString(R.string.buttons)
+        binding.homeHeader.homeGenericHeaderTitle.text = context?.getString(R.string.buttons)
     }
 }

--- a/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/CardsFragment.kt
+++ b/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/CardsFragment.kt
@@ -7,8 +7,8 @@ import com.spendesk.grapes.DeepBlueBucketView
 import com.spendesk.grapes.InformativeActionBucketView
 import com.spendesk.grapes.messages.MessageInlineView
 import com.spendesk.grapes.samples.R
-import kotlinx.android.synthetic.main.fragment_home_cards.*
-import kotlinx.android.synthetic.main.view_home_header.*
+import com.spendesk.grapes.samples.core.internal.viewBinding
+import com.spendesk.grapes.samples.databinding.FragmentHomeCardsBinding
 
 /**
  * @author danyboucanova
@@ -20,23 +20,25 @@ class CardsFragment : Fragment(R.layout.fragment_home_cards) {
         fun newInstance() = CardsFragment()
     }
 
+    private val binding by viewBinding(FragmentHomeCardsBinding::bind)
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        homeGenericHeaderTitle.text = context?.getString(R.string.cards)
+        binding.homeHeader.homeGenericHeaderTitle.text = context?.getString(R.string.cards)
 
         bindView()
     }
 
     private fun bindView() {
-        homeCardSectionOnTheWayDeepBlueBucketView.updateData(
+        binding.homeCardSectionOnTheWayDeepBlueBucketView.updateData(
             DeepBlueBucketView.Configuration(
                 title = requireContext().getString(R.string.homePushSectionOnTheWayDeepBlueBucketViewTitle),
                 description = requireContext().getString(R.string.homePushSectionOnTheWayDeepBlueBucketViewDescription),
                 buttonText = requireContext().getString(R.string.homePushSectionOnTheWayDeepBlueBucketViewButtonText)
             )
         )
-        homeCardSectionRecardDeepBlueBucketView.updateData(
+        binding.homeCardSectionRecardDeepBlueBucketView.updateData(
             DeepBlueBucketView.Configuration(
                 title = requireContext().getString(R.string.homePushSectionRecardDeepBlueBucketViewTitle),
                 description = requireContext().getString(R.string.homePushSectionRecardDeepBlueBucketViewDescription),
@@ -44,7 +46,7 @@ class CardsFragment : Fragment(R.layout.fragment_home_cards) {
             )
         )
 
-        homeCardSectionPlasticCardNormalInformativeActionBucketView.updateData(
+        binding.homeCardSectionPlasticCardNormalInformativeActionBucketView.updateData(
             InformativeActionBucketView.Configuration(
                 title = requireContext().getString(R.string.homePushSectionPlasticCardNormalInformativeActionBucketViewTitle),
                 smallButtonText = requireContext().getString(R.string.homePushSectionPlasticCardNormalInformativeActionBucketViewSmallButtonText),
@@ -54,7 +56,7 @@ class CardsFragment : Fragment(R.layout.fragment_home_cards) {
             )
         )
 
-        homeCardSectionPlasticCardWarningInformativeActionBucketView.updateData(
+        binding.homeCardSectionPlasticCardWarningInformativeActionBucketView.updateData(
             InformativeActionBucketView.Configuration(
                 title = requireContext().getString(R.string.homePushSectionPlasticCardWarningInformativeActionBucketViewTitle),
                 smallButtonText = requireContext().getString(R.string.homePushSectionPlasticCardWarningInformativeActionBucketViewSmallButtonText),
@@ -64,7 +66,7 @@ class CardsFragment : Fragment(R.layout.fragment_home_cards) {
             )
         )
 
-        homeCardSectionPlasticCardAlertInformativeActionBucketView.updateData(
+        binding.homeCardSectionPlasticCardAlertInformativeActionBucketView.updateData(
             InformativeActionBucketView.Configuration(
                 title = requireContext().getString(R.string.homePushSectionPlasticCardAlertInformativeActionBucketViewTitle),
                 smallButtonText = requireContext().getString(R.string.homePushSectionPlasticCardAlertInformativeActionBucketViewSmallButtonText),

--- a/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/ContentsFragment.kt
+++ b/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/ContentsFragment.kt
@@ -12,8 +12,8 @@ import com.spendesk.grapes.extensions.shortToaster
 import com.spendesk.grapes.list.content.summary.SummaryBlockContentModel
 import com.spendesk.grapes.list.content.summary.item.InlineKeyValueItemView
 import com.spendesk.grapes.samples.R
-import kotlinx.android.synthetic.main.fragment_home_contents.*
-import kotlinx.android.synthetic.main.view_home_header.*
+import com.spendesk.grapes.samples.core.internal.viewBinding
+import com.spendesk.grapes.samples.databinding.FragmentHomeContentsBinding
 
 /**
  * @author danyboucanova
@@ -25,10 +25,12 @@ class ContentsFragment : Fragment(R.layout.fragment_home_contents) {
         fun newInstance() = ContentsFragment()
     }
 
+    private val binding by viewBinding(FragmentHomeContentsBinding::bind)
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        homeGenericHeaderTitle.text = context?.getString(R.string.contents)
+        binding.homeHeader.homeGenericHeaderTitle.text = context?.getString(R.string.contents)
 
         setupView()
     }
@@ -41,7 +43,7 @@ class ContentsFragment : Fragment(R.layout.fragment_home_contents) {
 
     private fun setupBlockMap() {
         // Map extended
-        with(homeButtonSectionMapExtendedBlock) {
+        with(binding.homeButtonSectionMapExtendedBlock) {
             updateConfiguration(
                 configuration = SummaryBlockContentMapView.Configuration(
                     titleConfiguration = SummaryBlockTitleView.Configuration(
@@ -70,7 +72,7 @@ class ContentsFragment : Fragment(R.layout.fragment_home_contents) {
         }
 
         // Map compact
-        homeButtonSectionMapCompactBlock.updateConfiguration(
+        binding.homeButtonSectionMapCompactBlock.updateConfiguration(
             configuration = SummaryBlockContentMapView.Configuration(
                 titleConfiguration = SummaryBlockTitleView.Configuration(
                     startTitle = "Route"
@@ -88,7 +90,7 @@ class ContentsFragment : Fragment(R.layout.fragment_home_contents) {
 
     private fun setupBlockText() {
         // Text with value and image
-        with(homeButtonSectionTextWithValueAndImageBlock) {
+        with(binding.homeButtonSectionTextWithValueAndImageBlock) {
             updateConfiguration(
                 configuration = SummaryBlockContentTextView.Configuration(
                     titleConfiguration = SummaryBlockTitleView.Configuration(
@@ -104,7 +106,7 @@ class ContentsFragment : Fragment(R.layout.fragment_home_contents) {
         }
 
         // Text with value disabled
-        with(homeButtonSectionTextWithValueBlock) {
+        with(binding.homeButtonSectionTextWithValueBlock) {
             updateConfiguration(
                 configuration = SummaryBlockContentTextView.Configuration(
                     titleConfiguration = SummaryBlockTitleView.Configuration(
@@ -121,7 +123,7 @@ class ContentsFragment : Fragment(R.layout.fragment_home_contents) {
         }
 
         // Text with value selected
-        with(homeButtonSectionTextWithValueSelectedBlock) {
+        with(binding.homeButtonSectionTextWithValueSelectedBlock) {
             updateConfiguration(
                 configuration = SummaryBlockContentTextView.Configuration(
                     titleConfiguration = SummaryBlockTitleView.Configuration(
@@ -137,7 +139,7 @@ class ContentsFragment : Fragment(R.layout.fragment_home_contents) {
         }
 
         // Text without value
-        with(homeButtonSectionTextWithoutValueBlock) {
+        with(binding.homeButtonSectionTextWithoutValueBlock) {
             updateConfiguration(
                 configuration = SummaryBlockContentTextView.Configuration(
                     titleConfiguration = SummaryBlockTitleView.Configuration(
@@ -152,7 +154,7 @@ class ContentsFragment : Fragment(R.layout.fragment_home_contents) {
     }
 
     private fun setupCard() {
-        with(homeButtonSectionCardLinkBlock) {
+        with(binding.homeButtonSectionCardLinkBlock) {
             updateConfiguration(
                 configuration = SummaryCardLinkView.Configuration(
                     title = "Get virtual card details",

--- a/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/InputsFragment.kt
+++ b/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/InputsFragment.kt
@@ -6,8 +6,8 @@ import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
 import com.spendesk.grapes.extensions.shortToaster
 import com.spendesk.grapes.samples.R
-import kotlinx.android.synthetic.main.fragment_home_inputs.*
-import kotlinx.android.synthetic.main.view_home_header.*
+import com.spendesk.grapes.samples.core.internal.viewBinding
+import com.spendesk.grapes.samples.databinding.FragmentHomeInputsBinding
 
 /**
  * @author danyboucanova
@@ -19,13 +19,16 @@ class InputsFragment : Fragment(R.layout.fragment_home_inputs) {
         fun newInstance() = InputsFragment()
     }
 
+    private val binding by viewBinding(FragmentHomeInputsBinding::bind)
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        homeGenericHeaderTitle.text = context?.getString(R.string.inputs)
-
-        homeInputsSectionSearchMainPrimary.getEditText().doAfterTextChanged { requireActivity().shortToaster("Text changed: $it") }
-        homeInputsSectionSearchMainPrimaryLoading.showProgressBar(true)
-        homeInputsSectionSearchMainSecondaryLoading.showProgressBar(true)
+        with(binding) {
+            homeHeader.homeGenericHeaderTitle.text = context?.getString(R.string.inputs)
+            homeInputsSectionSearchMainPrimary.getEditText().doAfterTextChanged { requireActivity().shortToaster("Text changed: $it") }
+            homeInputsSectionSearchMainPrimaryLoading.showProgressBar(true)
+            homeInputsSectionSearchMainSecondaryLoading.showProgressBar(true)
+        }
     }
 }

--- a/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/KeyboardsFragment.kt
+++ b/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/KeyboardsFragment.kt
@@ -6,8 +6,8 @@ import androidx.fragment.app.Fragment
 import com.spendesk.grapes.NumberKeyboard
 import com.spendesk.grapes.extensions.shortToaster
 import com.spendesk.grapes.samples.R
-import kotlinx.android.synthetic.main.fragment_home_keyboards.*
-import kotlinx.android.synthetic.main.view_home_header.*
+import com.spendesk.grapes.samples.core.internal.viewBinding
+import com.spendesk.grapes.samples.databinding.FragmentHomeKeyboardsBinding
 
 /**
  * @author Vivien Mahe
@@ -19,12 +19,14 @@ class KeyboardsFragment : Fragment(R.layout.fragment_home_keyboards) {
         fun newInstance() = KeyboardsFragment()
     }
 
+    private val binding by viewBinding(FragmentHomeKeyboardsBinding::bind)
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        homeGenericHeaderTitle.text = context?.getString(R.string.inputs)
+        binding.homeHeader.homeGenericHeaderTitle.text = context?.getString(R.string.inputs)
 
-        with(homeKeyboardsSectionOne) {
+        with(binding.homeKeyboardsSectionOne) {
             updateConfiguration(
                 configuration = NumberKeyboard.Configuration(
                     style = NumberKeyboard.Style.LIGHT,
@@ -36,13 +38,13 @@ class KeyboardsFragment : Fragment(R.layout.fragment_home_keyboards) {
             onRequestedBiometricAuthentication = { activity?.shortToaster("Biometric key pressed") }
         }
 
-        with(homeKeyboardsSectionTwo) {
+        with(binding.homeKeyboardsSectionTwo) {
             // FYI: Configuration is set via XML attrs
             onTextChanged = { activity?.shortToaster("Key pressed: $it") }
             onRequestedBiometricAuthentication = { activity?.shortToaster("Separator key pressed") }
         }
 
-        with(homeKeyboardsSectionThree) {
+        with(binding.homeKeyboardsSectionThree) {
             // FYI: Configuration is set via XML attrs
             onTextChanged = { activity?.shortToaster("Key pressed: $it") }
             onRequestedBiometricAuthentication = { activity?.shortToaster("Separator key pressed") }

--- a/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/ListsFragment.kt
+++ b/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/ListsFragment.kt
@@ -10,8 +10,8 @@ import com.spendesk.grapes.list.simple.SimpleListAdapter
 import com.spendesk.grapes.list.simple.SimpleListModel
 import com.spendesk.grapes.messages.MessageInlineView
 import com.spendesk.grapes.samples.R
-import kotlinx.android.synthetic.main.fragment_home_lists.*
-import kotlinx.android.synthetic.main.view_home_header.*
+import com.spendesk.grapes.samples.core.internal.viewBinding
+import com.spendesk.grapes.samples.databinding.FragmentHomeListsBinding
 
 /**
  * @author danyboucanova
@@ -23,12 +23,13 @@ class ListsFragment : Fragment(R.layout.fragment_home_lists) {
         fun newInstance() = ListsFragment()
     }
 
+    private val binding by viewBinding(FragmentHomeListsBinding::bind)
     private val adapter = SimpleListAdapter()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        homeGenericHeaderTitle.text = context?.getString(R.string.lists)
+        binding.homeHeader.homeGenericHeaderTitle.text = context?.getString(R.string.lists)
 
         setupView()
     }
@@ -166,7 +167,7 @@ class ListsFragment : Fragment(R.layout.fragment_home_lists) {
         )
 
         // List
-        homeListsSectionList.adapter = adapter
+        binding.homeListsSectionList.adapter = adapter
 
         adapter.updateList(
             items = listOf(

--- a/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/LoadersFragment.kt
+++ b/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/LoadersFragment.kt
@@ -4,7 +4,8 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
 import com.spendesk.grapes.samples.R
-import kotlinx.android.synthetic.main.view_home_header.*
+import com.spendesk.grapes.samples.core.internal.viewBinding
+import com.spendesk.grapes.samples.databinding.FragmentHomeLoadersBinding
 
 /**
  * @author Vivien Mahe
@@ -16,9 +17,11 @@ class LoadersFragment : Fragment(R.layout.fragment_home_loaders) {
         fun newInstance() = LoadersFragment()
     }
 
+    private val binding by viewBinding(FragmentHomeLoadersBinding::bind)
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        homeGenericHeaderTitle.text = context?.getString(R.string.loaders)
+        binding.homeHeader.homeGenericHeaderTitle.text = context?.getString(R.string.loaders)
     }
 }

--- a/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/SelectorFragment.kt
+++ b/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/SelectorFragment.kt
@@ -5,9 +5,9 @@ import android.view.View
 import androidx.fragment.app.Fragment
 import com.spendesk.grapes.extensions.shortToaster
 import com.spendesk.grapes.samples.R
+import com.spendesk.grapes.samples.core.internal.viewBinding
+import com.spendesk.grapes.samples.databinding.FragmentHomeSelectorsBinding
 import com.spendesk.grapes.selectors.*
-import kotlinx.android.synthetic.main.fragment_home_selectors.*
-import kotlinx.android.synthetic.main.view_home_header.*
 import kotlin.random.Random
 
 /**
@@ -20,10 +20,12 @@ class SelectorFragment : Fragment(R.layout.fragment_home_selectors) {
         fun newInstance() = SelectorFragment()
     }
 
+    private val binding by viewBinding(FragmentHomeSelectorsBinding::bind)
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        homeGenericHeaderTitle.text = context?.getString(R.string.selectors)
+        binding.homeHeader.homeGenericHeaderTitle.text = context?.getString(R.string.selectors)
 
         bindView()
     }
@@ -32,157 +34,159 @@ class SelectorFragment : Fragment(R.layout.fragment_home_selectors) {
     private var maxAnimatedStatusIndex = 5
 
     private fun bindView() {
-        // Header Pager Indicator
-        homeSelectorsSectionHeaderStatusIndicatorFirstHeaderStatusIndicator.updateConfiguration(HeaderStatusIndicator.Configuration(5))
-        homeSelectorsSectionHeaderStatusIndicatorFirstHeaderStatusIndicator.updateStatusIndex(0)
+        with(binding) {
+            // Header Pager Indicator
+            homeSelectorsSectionHeaderStatusIndicatorFirstHeaderStatusIndicator.updateConfiguration(HeaderStatusIndicator.Configuration(5))
+            homeSelectorsSectionHeaderStatusIndicatorFirstHeaderStatusIndicator.updateStatusIndex(0)
 
-        homeSelectorsSectionHeaderStatusIndicatorSecondHeaderStatusIndicator.updateConfiguration(HeaderStatusIndicator.Configuration(5))
-        homeSelectorsSectionHeaderStatusIndicatorSecondHeaderStatusIndicator.updateStatusIndex(2)
+            homeSelectorsSectionHeaderStatusIndicatorSecondHeaderStatusIndicator.updateConfiguration(HeaderStatusIndicator.Configuration(5))
+            homeSelectorsSectionHeaderStatusIndicatorSecondHeaderStatusIndicator.updateStatusIndex(2)
 
-        homeSelectorsSectionHeaderStatusIndicatorThirdHeaderStatusIndicator.updateConfiguration(HeaderStatusIndicator.Configuration(5))
-        homeSelectorsSectionHeaderStatusIndicatorThirdHeaderStatusIndicator.updateStatusIndex(5)
+            homeSelectorsSectionHeaderStatusIndicatorThirdHeaderStatusIndicator.updateConfiguration(HeaderStatusIndicator.Configuration(5))
+            homeSelectorsSectionHeaderStatusIndicatorThirdHeaderStatusIndicator.updateStatusIndex(5)
 
-        homeSelectorsSectionHeaderStatusIndicatorFourthHeaderStatusIndicator.updateConfiguration(HeaderStatusIndicator.Configuration(maxAnimatedStatusIndex))
-        homeSelectorsSectionHeaderStatusIndicatorFourthHeaderStatusIndicator.updateStatusIndex(currentAnimatedStatusIndex)
+            homeSelectorsSectionHeaderStatusIndicatorFourthHeaderStatusIndicator.updateConfiguration(HeaderStatusIndicator.Configuration(maxAnimatedStatusIndex))
+            homeSelectorsSectionHeaderStatusIndicatorFourthHeaderStatusIndicator.updateStatusIndex(currentAnimatedStatusIndex)
 
-        homeSelectorsSectionHeaderStatusIndicatorFourthSubtitle.setOnClickListener {
-            currentAnimatedStatusIndex = (currentAnimatedStatusIndex - 1) % maxAnimatedStatusIndex
-            homeSelectorsSectionHeaderStatusIndicatorFourthHeaderStatusIndicator.updateStatusIndex(currentAnimatedStatusIndex, true)
-        }
+            homeSelectorsSectionHeaderStatusIndicatorFourthSubtitle.setOnClickListener {
+                currentAnimatedStatusIndex = (currentAnimatedStatusIndex - 1) % maxAnimatedStatusIndex
+                homeSelectorsSectionHeaderStatusIndicatorFourthHeaderStatusIndicator.updateStatusIndex(currentAnimatedStatusIndex, true)
+            }
 
-        homeSelectorsSectionHeaderStatusIndicatorFourthRandomButton.setOnClickListener {
-            currentAnimatedStatusIndex = Random.nextInt(0, maxAnimatedStatusIndex)
-            activity?.shortToaster("Show index $currentAnimatedStatusIndex")
-            homeSelectorsSectionHeaderStatusIndicatorFourthHeaderStatusIndicator.updateStatusIndex(currentAnimatedStatusIndex, true)
-        }
+            homeSelectorsSectionHeaderStatusIndicatorFourthRandomButton.setOnClickListener {
+                currentAnimatedStatusIndex = Random.nextInt(0, maxAnimatedStatusIndex)
+                activity?.shortToaster("Show index $currentAnimatedStatusIndex")
+                homeSelectorsSectionHeaderStatusIndicatorFourthHeaderStatusIndicator.updateStatusIndex(currentAnimatedStatusIndex, true)
+            }
 
-        homeSelectorsSectionHeaderStatusIndicatorFourthHeaderStatusIndicator.setOnClickListener {
-            currentAnimatedStatusIndex = (currentAnimatedStatusIndex + 1) % maxAnimatedStatusIndex
-            homeSelectorsSectionHeaderStatusIndicatorFourthHeaderStatusIndicator.updateStatusIndex(currentAnimatedStatusIndex, true)
-        }
+            homeSelectorsSectionHeaderStatusIndicatorFourthHeaderStatusIndicator.setOnClickListener {
+                currentAnimatedStatusIndex = (currentAnimatedStatusIndex + 1) % maxAnimatedStatusIndex
+                homeSelectorsSectionHeaderStatusIndicatorFourthHeaderStatusIndicator.updateStatusIndex(currentAnimatedStatusIndex, true)
+            }
 
-        homeSelectorsSectionHeaderStatusIndicatorFifthHeaderStatusIndicator.updateConfiguration(HeaderStatusIndicator.Configuration(5))
-        homeSelectorsSectionHeaderStatusIndicatorFifthHeaderStatusIndicator.updateStatusIndex(3)
+            homeSelectorsSectionHeaderStatusIndicatorFifthHeaderStatusIndicator.updateConfiguration(HeaderStatusIndicator.Configuration(5))
+            homeSelectorsSectionHeaderStatusIndicatorFifthHeaderStatusIndicator.updateStatusIndex(3)
 
-        homeSelectorsSectionHeaderStatusIndicatorFifthRandomButton.setOnClickListener {
-            val newMaxItems = Random.nextInt(1, 5)
-            activity?.shortToaster("Show max item $newMaxItems")
-            homeSelectorsSectionHeaderStatusIndicatorFifthHeaderStatusIndicator.updateConfiguration(HeaderStatusIndicator.Configuration(newMaxItems), shouldAnimate = true)
-        }
+            homeSelectorsSectionHeaderStatusIndicatorFifthRandomButton.setOnClickListener {
+                val newMaxItems = Random.nextInt(1, 5)
+                activity?.shortToaster("Show max item $newMaxItems")
+                homeSelectorsSectionHeaderStatusIndicatorFifthHeaderStatusIndicator.updateConfiguration(HeaderStatusIndicator.Configuration(newMaxItems), shouldAnimate = true)
+            }
 
-        // Picker Cards List
-        val pickerCardListViewAdapter = PickerAdapter()
-        val pickerCardListModel = listOf<PickerModel>(
-            PickerModel.Block(id = "lel", configuration = PickerBlockIconCardView.Configuration(isSelected = false, android.R.drawable.ic_media_previous)),
-            PickerModel.Block(id = "lol", configuration = PickerBlockIconCardView.Configuration(isSelected = true, android.R.drawable.ic_media_play)),
-            PickerModel.Block(id = "lille", configuration = PickerBlockIconCardView.Configuration(isSelected = false, android.R.drawable.ic_media_next))
-        )
-
-        homeSelectorsSectionPickerListView.adapter = pickerCardListViewAdapter
-        pickerCardListViewAdapter.onItemSelected = { _, _ -> activity?.shortToaster("Picker Card Item List Checked !") }
-        pickerCardListViewAdapter.updateList(pickerCardListModel)
-
-
-        // Picker Texts List
-        val pickerTextListViewAdapter = PickerAdapter()
-        val pickerTextListModel = listOf<PickerModel>(
-            PickerModel.Label(id = "hoy", configuration = PickerLabelTextView.Configuration(isSelected = false, "level 1")),
-            PickerModel.Label(id = "hey", configuration = PickerLabelTextView.Configuration(isSelected = false, "level 2")),
-            PickerModel.Label(id = "hoyjoy", configuration = PickerLabelTextView.Configuration(isSelected = false, "level 3")),
-            PickerModel.Label(id = "uesh", configuration = PickerLabelTextView.Configuration(isSelected = false, "level 4"))
-        )
-        homeSelectorsSectionPickerTextListView.adapter = pickerTextListViewAdapter
-        pickerTextListViewAdapter.onItemSelected = { _, _ -> activity?.shortToaster("Picker Card Item List Checked !") }
-        pickerTextListViewAdapter.updateList(pickerTextListModel)
-
-        // SwitchCard
-        homeSelectorsSectionSwitchCard.updateConfiguration(SwitchCardView.Configuration(text = "I AM the subtitle", isChecked = false))
-
-        // Selector
-        homeSelectorsSectionSelectorOne.updateConfiguration(
-            configuration = SelectorView.Configuration(
-                style = SelectorView.Style.PRIMARY,
-                text = "Primary",
-                notificationText = null,
-                shouldShowDrawableEnd = false
+            // Picker Cards List
+            val pickerCardListViewAdapter = PickerAdapter()
+            val pickerCardListModel = listOf<PickerModel>(
+                PickerModel.Block(id = "lel", configuration = PickerBlockIconCardView.Configuration(isSelected = false, android.R.drawable.ic_media_previous)),
+                PickerModel.Block(id = "lol", configuration = PickerBlockIconCardView.Configuration(isSelected = true, android.R.drawable.ic_media_play)),
+                PickerModel.Block(id = "lille", configuration = PickerBlockIconCardView.Configuration(isSelected = false, android.R.drawable.ic_media_next))
             )
-        )
 
-        homeSelectorsSectionSelectorTwo.updateConfiguration(
-            configuration = SelectorView.Configuration(
-                style = SelectorView.Style.SECONDARY,
-                text = "Secondary",
-                notificationText = "1",
-                shouldShowDrawableEnd = true
+            homeSelectorsSectionPickerListView.adapter = pickerCardListViewAdapter
+            pickerCardListViewAdapter.onItemSelected = { _, _ -> activity?.shortToaster("Picker Card Item List Checked !") }
+            pickerCardListViewAdapter.updateList(pickerCardListModel)
+
+
+            // Picker Texts List
+            val pickerTextListViewAdapter = PickerAdapter()
+            val pickerTextListModel = listOf<PickerModel>(
+                PickerModel.Label(id = "hoy", configuration = PickerLabelTextView.Configuration(isSelected = false, "level 1")),
+                PickerModel.Label(id = "hey", configuration = PickerLabelTextView.Configuration(isSelected = false, "level 2")),
+                PickerModel.Label(id = "hoyjoy", configuration = PickerLabelTextView.Configuration(isSelected = false, "level 3")),
+                PickerModel.Label(id = "uesh", configuration = PickerLabelTextView.Configuration(isSelected = false, "level 4"))
             )
-        )
+            homeSelectorsSectionPickerTextListView.adapter = pickerTextListViewAdapter
+            pickerTextListViewAdapter.onItemSelected = { _, _ -> activity?.shortToaster("Picker Card Item List Checked !") }
+            pickerTextListViewAdapter.updateList(pickerTextListModel)
 
-        homeSelectorsSectionSelectorThree.updateConfiguration(
-            configuration = SelectorView.Configuration(
-                style = SelectorView.Style.ACTIVE_PRIMARY,
-                text = "Active Primary",
-                notificationText = null,
-                shouldShowDrawableEnd = true
+            // SwitchCard
+            homeSelectorsSectionSwitchCard.updateConfiguration(SwitchCardView.Configuration(text = "I AM the subtitle", isChecked = false))
+
+            // Selector
+            homeSelectorsSectionSelectorOne.updateConfiguration(
+                configuration = SelectorView.Configuration(
+                    style = SelectorView.Style.PRIMARY,
+                    text = "Primary",
+                    notificationText = null,
+                    shouldShowDrawableEnd = false
+                )
             )
-        )
-        homeSelectorsSectionSelectorFour.updateConfiguration(
-            configuration = SelectorView.Configuration(
-                style = SelectorView.Style.ACTIVE_PRIMARY_DARK,
-                text = "Active Primary Dark",
-                notificationText = null,
-                shouldShowDrawableEnd = true
+
+            homeSelectorsSectionSelectorTwo.updateConfiguration(
+                configuration = SelectorView.Configuration(
+                    style = SelectorView.Style.SECONDARY,
+                    text = "Secondary",
+                    notificationText = "1",
+                    shouldShowDrawableEnd = true
+                )
             )
-        )
 
-        // Tabs
-        homeSelectorsSectionTabCardViewTabLayoutOne.addTab(homeSelectorsSectionTabCardViewTabLayoutOne.newTab())
-        homeSelectorsSectionTabCardViewTabLayoutOne.addTab(homeSelectorsSectionTabCardViewTabLayoutOne.newTab())
-        homeSelectorsSectionTabCardViewTabLayoutOne.getTabAt(0)?.customView =
-            TabCardView(requireContext())
-                .apply {
-                    updateConfiguration(
-                        configuration = TabCardView.Configuration(
-                            text = "Rick",
-                            badgeNumber = "4",
-                            isActivated = true
-                        )
-                    )
-                }
-        homeSelectorsSectionTabCardViewTabLayoutOne.getTabAt(1)?.customView =
-            TabCardView(requireContext())
-                .apply {
-                    updateConfiguration(
-                        configuration = TabCardView.Configuration(
-                            text = "Astley",
-                            badgeNumber = "2",
-                            isActivated = true
-                        )
-                    )
-                }
+            homeSelectorsSectionSelectorThree.updateConfiguration(
+                configuration = SelectorView.Configuration(
+                    style = SelectorView.Style.ACTIVE_PRIMARY,
+                    text = "Active Primary",
+                    notificationText = null,
+                    shouldShowDrawableEnd = true
+                )
+            )
+            homeSelectorsSectionSelectorFour.updateConfiguration(
+                configuration = SelectorView.Configuration(
+                    style = SelectorView.Style.ACTIVE_PRIMARY_DARK,
+                    text = "Active Primary Dark",
+                    notificationText = null,
+                    shouldShowDrawableEnd = true
+                )
+            )
 
-        homeSelectorsSectionTabCardViewTabLayoutTwo.addTab(homeSelectorsSectionTabCardViewTabLayoutTwo.newTab())
-        homeSelectorsSectionTabCardViewTabLayoutTwo.addTab(homeSelectorsSectionTabCardViewTabLayoutTwo.newTab())
-        homeSelectorsSectionTabCardViewTabLayoutTwo.getTabAt(0)?.customView =
-            TabCardView(requireContext())
-                .apply {
-                    updateConfiguration(
-                        configuration = TabCardView.Configuration(
-                            text = "Rick",
-                            badgeNumber = "4",
-                            isActivated = false
+            // Tabs
+            homeSelectorsSectionTabCardViewTabLayoutOne.addTab(homeSelectorsSectionTabCardViewTabLayoutOne.newTab())
+            homeSelectorsSectionTabCardViewTabLayoutOne.addTab(homeSelectorsSectionTabCardViewTabLayoutOne.newTab())
+            homeSelectorsSectionTabCardViewTabLayoutOne.getTabAt(0)?.customView =
+                TabCardView(requireContext())
+                    .apply {
+                        updateConfiguration(
+                            configuration = TabCardView.Configuration(
+                                text = "Rick",
+                                badgeNumber = "4",
+                                isActivated = true
+                            )
                         )
-                    )
-                }
-        homeSelectorsSectionTabCardViewTabLayoutTwo.getTabAt(1)?.customView =
-            TabCardView(requireContext())
-                .apply {
-                    updateConfiguration(
-                        configuration = TabCardView.Configuration(
-                            text = "Astley",
-                            badgeNumber = "2",
-                            isActivated = false
+                    }
+            homeSelectorsSectionTabCardViewTabLayoutOne.getTabAt(1)?.customView =
+                TabCardView(requireContext())
+                    .apply {
+                        updateConfiguration(
+                            configuration = TabCardView.Configuration(
+                                text = "Astley",
+                                badgeNumber = "2",
+                                isActivated = true
+                            )
                         )
-                    )
-                }
+                    }
+
+            homeSelectorsSectionTabCardViewTabLayoutTwo.addTab(homeSelectorsSectionTabCardViewTabLayoutTwo.newTab())
+            homeSelectorsSectionTabCardViewTabLayoutTwo.addTab(homeSelectorsSectionTabCardViewTabLayoutTwo.newTab())
+            homeSelectorsSectionTabCardViewTabLayoutTwo.getTabAt(0)?.customView =
+                TabCardView(requireContext())
+                    .apply {
+                        updateConfiguration(
+                            configuration = TabCardView.Configuration(
+                                text = "Rick",
+                                badgeNumber = "4",
+                                isActivated = false
+                            )
+                        )
+                    }
+            homeSelectorsSectionTabCardViewTabLayoutTwo.getTabAt(1)?.customView =
+                TabCardView(requireContext())
+                    .apply {
+                        updateConfiguration(
+                            configuration = TabCardView.Configuration(
+                                text = "Astley",
+                                badgeNumber = "2",
+                                isActivated = false
+                            )
+                        )
+                    }
+        }
     }
 }

--- a/sample/src/main/res/layout/fragment_home_bottom_sheets.xml
+++ b/sample/src/main/res/layout/fragment_home_bottom_sheets.xml
@@ -9,7 +9,14 @@
         android:layout_width="match_parent"
         android:layout_height="0dp">
 
-        <include layout="@layout/view_home_header" />
+        <include
+            android:id="@+id/homeHeader"
+            layout="@layout/view_home_header"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
             android:id="@+id/homeBottomSheetsSectionSearchableText"
@@ -22,7 +29,7 @@
             android:text="@string/bottomSheetsSearchableTitle"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/homeGenericHeaderBackground" />
+            app:layout_constraintTop_toBottomOf="@+id/homeHeader" />
 
         <com.spendesk.grapes.BucketView
             android:id="@+id/homeBottomSheetsSectionSearchableBucketView"

--- a/sample/src/main/res/layout/fragment_home_buttons.xml
+++ b/sample/src/main/res/layout/fragment_home_buttons.xml
@@ -9,7 +9,14 @@
         android:layout_width="match_parent"
         android:layout_height="0dp">
 
-        <include layout="@layout/view_home_header" />
+        <include
+            android:id="@+id/homeHeader"
+            layout="@layout/view_home_header"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <!-- region primary -->
         <TextView
@@ -23,7 +30,7 @@
             android:text="@string/buttonPrimary"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/homeGenericHeaderBackground" />
+            app:layout_constraintTop_toBottomOf="@+id/homeHeader" />
 
         <com.spendesk.grapes.BucketView
             android:id="@+id/homeButtonSectionPrimaryBucketView"

--- a/sample/src/main/res/layout/fragment_home_cards.xml
+++ b/sample/src/main/res/layout/fragment_home_cards.xml
@@ -9,7 +9,14 @@
         android:layout_width="match_parent"
         android:layout_height="0dp">
 
-        <include layout="@layout/view_home_header" />
+        <include
+            android:id="@+id/homeHeader"
+            layout="@layout/view_home_header"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <!-- region purple-->
         <TextView
@@ -23,7 +30,7 @@
             android:text="@string/cardPurple"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/homeGenericHeaderBackground" />
+            app:layout_constraintTop_toBottomOf="@+id/homeHeader" />
 
         <com.spendesk.grapes.BucketView
             android:id="@+id/homeCardSectionPurpleBucketView"
@@ -235,14 +242,14 @@
                 <com.spendesk.grapes.RegistrationCodeView
                     android:layout_width="0dp"
                     android:layout_height="56dp"
-                    app:layout_constraintTop_toBottomOf="@+id/homeCardSectionRegistrationCodeNormalSubtitle"
-                    app:layout_constraintBottom_toBottomOf="parent"
                     android:layout_marginStart="@dimen/homeSectionSubtitleMarginHorz"
                     android:layout_marginTop="@dimen/homeSectionSubtitleMarginVert"
-                    android:layout_marginBottom="@dimen/homeSectionSubtitleMarginVert"
                     android:layout_marginEnd="@dimen/homeSectionSubtitleMarginHorz"
+                    android:layout_marginBottom="@dimen/homeSectionSubtitleMarginVert"
+                    app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent" />
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/homeCardSectionRegistrationCodeNormalSubtitle" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
         </com.spendesk.grapes.BucketView>

--- a/sample/src/main/res/layout/fragment_home_contents.xml
+++ b/sample/src/main/res/layout/fragment_home_contents.xml
@@ -9,7 +9,14 @@
         android:layout_width="match_parent"
         android:layout_height="0dp">
 
-        <include layout="@layout/view_home_header" />
+        <include
+            android:id="@+id/homeHeader"
+            layout="@layout/view_home_header"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <!-- region Map -->
         <TextView
@@ -23,7 +30,7 @@
             android:text="@string/contentMap"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/homeGenericHeaderBackground" />
+            app:layout_constraintTop_toBottomOf="@id/homeHeader" />
 
         <com.spendesk.grapes.BucketView
             android:id="@+id/homeButtonSectionMapBucketView"

--- a/sample/src/main/res/layout/fragment_home_inputs.xml
+++ b/sample/src/main/res/layout/fragment_home_inputs.xml
@@ -9,7 +9,14 @@
         android:layout_width="match_parent"
         android:layout_height="0dp">
 
-        <include layout="@layout/view_home_header" />
+        <include
+            android:id="@+id/homeHeader"
+            layout="@layout/view_home_header"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
             android:id="@+id/homeInputsSectionSearchMainTitleText"
@@ -22,7 +29,7 @@
             android:text="@string/inputSearchMain"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/homeGenericHeaderBackground" />
+            app:layout_constraintTop_toBottomOf="@+id/homeHeader" />
 
         <com.spendesk.grapes.BucketView
             android:id="@+id/homeInputsSectionSearchMainBucketView"
@@ -61,10 +68,10 @@
                     android:layout_marginEnd="@dimen/homeSectionComponentMarginHorz"
                     android:layout_marginBottom="@dimen/homeSectionComponentMarginVert"
                     android:drawableStart="@drawable/ic_search"
+                    app:inputSearchMainStyle="primary"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/homeInputsSectionSearchMainPrimarySubtitle"
-                    app:inputSearchMainStyle="primary" />
+                    app:layout_constraintTop_toBottomOf="@id/homeInputsSectionSearchMainPrimarySubtitle" />
 
                 <TextView
                     android:id="@+id/homeInputsSectionSearchMainPrimaryLoadingSubtitle"
@@ -88,10 +95,10 @@
                     android:layout_marginEnd="@dimen/homeSectionComponentMarginHorz"
                     android:layout_marginBottom="@dimen/homeSectionComponentMarginVert"
                     android:drawableStart="@drawable/ic_search"
+                    app:inputSearchMainStyle="primary"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/homeInputsSectionSearchMainPrimaryLoadingSubtitle"
-                    app:inputSearchMainStyle="primary" />
+                    app:layout_constraintTop_toBottomOf="@id/homeInputsSectionSearchMainPrimaryLoadingSubtitle" />
 
                 <TextView
                     android:id="@+id/homeInputsSectionSearchMainSecondarySubtitle"
@@ -115,10 +122,10 @@
                     android:layout_marginEnd="@dimen/homeSectionComponentMarginHorz"
                     android:layout_marginBottom="@dimen/homeSectionComponentMarginVert"
                     android:drawableStart="@drawable/ic_search"
+                    app:inputSearchMainStyle="secondary"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/homeInputsSectionSearchMainSecondarySubtitle"
-                    app:inputSearchMainStyle="secondary" />
+                    app:layout_constraintTop_toBottomOf="@id/homeInputsSectionSearchMainSecondarySubtitle" />
 
                 <TextView
                     android:id="@+id/homeInputsSectionSearchMainSecondaryLoadingSubtitle"
@@ -142,11 +149,11 @@
                     android:layout_marginEnd="@dimen/homeSectionComponentMarginHorz"
                     android:layout_marginBottom="@dimen/homeSectionComponentMarginVert"
                     android:drawableStart="@drawable/ic_search"
+                    app:inputSearchMainStyle="secondary"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/homeInputsSectionSearchMainSecondaryLoadingSubtitle"
-                    app:inputSearchMainStyle="secondary" />
+                    app:layout_constraintTop_toBottomOf="@id/homeInputsSectionSearchMainSecondaryLoadingSubtitle" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </com.spendesk.grapes.BucketView>
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/layout/fragment_home_keyboards.xml
+++ b/sample/src/main/res/layout/fragment_home_keyboards.xml
@@ -9,7 +9,14 @@
         android:layout_width="match_parent"
         android:layout_height="0dp">
 
-        <include layout="@layout/view_home_header" />
+        <include
+            android:id="@+id/homeHeader"
+            layout="@layout/view_home_header"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
             android:id="@+id/homeKeyboardsSectionTitleText"
@@ -22,7 +29,7 @@
             android:text="@string/keyboardsTitle"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/homeGenericHeaderBackground" />
+            app:layout_constraintTop_toBottomOf="@+id/homeHeader" />
 
         <com.spendesk.grapes.BucketView
             android:id="@+id/homeKeyboardsSectionSearchMainBucketView"

--- a/sample/src/main/res/layout/fragment_home_lists.xml
+++ b/sample/src/main/res/layout/fragment_home_lists.xml
@@ -9,7 +9,14 @@
         android:layout_width="match_parent"
         android:layout_height="0dp">
 
-        <include layout="@layout/view_home_header" />
+        <include
+            android:id="@+id/homeHeader"
+            layout="@layout/view_home_header"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
             android:id="@+id/homeListsSectionListText"
@@ -22,7 +29,7 @@
             android:text="@string/listTitle"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/homeGenericHeaderBackground" />
+            app:layout_constraintTop_toBottomOf="@+id/homeHeader" />
 
         <com.spendesk.grapes.BucketView
             android:id="@+id/homeListsSectionListBucketView"

--- a/sample/src/main/res/layout/fragment_home_loaders.xml
+++ b/sample/src/main/res/layout/fragment_home_loaders.xml
@@ -9,7 +9,14 @@
         android:layout_width="match_parent"
         android:layout_height="0dp">
 
-        <include layout="@layout/view_home_header" />
+        <include
+            android:id="@+id/homeHeader"
+            layout="@layout/view_home_header"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <!-- region CircularProgressBar -->
 
@@ -24,7 +31,7 @@
             android:text="@string/loadersCircularProgressBar"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/homeGenericHeaderBackground" />
+            app:layout_constraintTop_toBottomOf="@id/homeHeader" />
 
         <com.spendesk.grapes.BucketView
             android:id="@+id/homeLoadersSectionCircularProgressBarBucketView"

--- a/sample/src/main/res/layout/fragment_home_selectors.xml
+++ b/sample/src/main/res/layout/fragment_home_selectors.xml
@@ -10,7 +10,14 @@
         android:layout_width="match_parent"
         android:layout_height="0dp">
 
-        <include layout="@layout/view_home_header" />
+        <include
+            android:id="@+id/homeHeader"
+            layout="@layout/view_home_header"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
             android:id="@+id/homeSelectorsSectionHeaderStatusIndicatorTitleText"
@@ -22,7 +29,7 @@
             android:text="@string/selectorsPickerCardsListView"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/homeGenericHeaderBackground" />
+            app:layout_constraintTop_toBottomOf="@+id/homeHeader" />
 
         <com.spendesk.grapes.BucketView
             android:id="@+id/homeSelectorsSectionHeaderStatusIndicatorBucketView"
@@ -163,8 +170,8 @@
                     android:layout_height="24dp"
                     android:layout_marginEnd="16dp"
                     android:background="?selectableItemBackgroundBorderless"
-                    android:src="@drawable/ic_loop"
                     android:gravity="center"
+                    android:src="@drawable/ic_loop"
                     app:layout_constraintBottom_toBottomOf="@+id/homeSelectorsSectionHeaderStatusIndicatorFifthSubtitle"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toEndOf="@+id/homeSelectorsSectionHeaderStatusIndicatorFifthSubtitle"

--- a/sample/src/main/res/layout/view_home_header.xml
+++ b/sample/src/main/res/layout/view_home_header.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
 
     <View
         android:id="@+id/homeGenericHeaderBackground"
@@ -25,4 +26,4 @@
         app:layout_constraintStart_toStartOf="@id/homeGenericHeaderBackground"
         app:layout_constraintTop_toTopOf="@id/homeGenericHeaderBackground"
         tools:text="Buttons" />
-</merge>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/values/ids.xml
+++ b/sample/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="view_binding_tag" type="id" />
+</resources>


### PR DESCRIPTION
kotlin-android-extension, which mainly embed synthetics and parcelable annotation is deprecated.

This PR removes any usage of this plugin
-> Replace synthetics usage by viewBinding
-> Use [kotlin-parcelize](https://developer.android.com/kotlin/parcelize) annotation