### PR TITLE
Fix a crash from the EditTextExtensions when using afterTextChanged

### DIFF
--- a/library/src/main/java/com/spendesk/grapes/bottomsheet/editabletext/EditableTextBottomSheetDialogFragment.kt
+++ b/library/src/main/java/com/spendesk/grapes/bottomsheet/editabletext/EditableTextBottomSheetDialogFragment.kt
@@ -134,7 +134,7 @@ class EditableTextBottomSheetDialogFragment : BottomSheetDialogFragment() {
         binding?.apply {
             headerCloseButton.setOnClickListener { dismiss() }
             validateButton.setOnClickListener { withActivityAttached { runOnUiThread { onValidateButtonClicked?.invoke(editText.text.toString().trim()) } } }
-            editText.afterTextChangedWith(EDITTEXT_TEXT_CHANGED_DELAY) { withActivityAttached { runOnUiThread { updateValidateButton() } } }
+            editText.onTextChanged { withActivityAttached { runOnUiThread { updateValidateButton() } } }
         }
     }
 

--- a/library/src/main/java/com/spendesk/grapes/extensions/EditTextExtensions.kt
+++ b/library/src/main/java/com/spendesk/grapes/extensions/EditTextExtensions.kt
@@ -42,21 +42,31 @@ internal fun EditText.afterTextChangedWith(delay: Long, consumer: (String) -> Un
         override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
 
         override fun afterTextChanged(editable: Editable?) {
-            timer.cancel()
-            timer = Timer().apply {
-                schedule(delay) {
-                    try {
-                        if (editable.isNullOrEmpty().not()) consumer(editable.toString())
-                    } catch (exception: IndexOutOfBoundsException) {
-                        // A crash randomly happens here causing an IndexOutOfBoundsException when toString() tries to get the characters from the EditText
-                        // https://console.firebase.google.com/u/0/project/spendesk-mobile/crashlytics/app/android:com.spendesk.spendesk/issues/366c950f3b688d79a5de9004b6c5e947?time=last-ninety-days&types=crash&versions=2.23.4%20(22302888);2.23.3%20(22302887)&sessionEventKey=6297C55100E60001732296088542CD65_1682809803838467563
-                        // There is nothing much we can do here to get the text from the EditText if this method fails, so we just catch it to avoid a crash.
-                    }
+            try {
+                editable?.let {
+                    val newText = editable.toString()
+
+                    timer.cancel()
+                    timer = Timer().apply { schedule(delay) { consumer(newText) } }
                 }
+            } catch (exception: IndexOutOfBoundsException) {
+                // A crash randomly happens here causing an IndexOutOfBoundsException when toString() tries to get the characters from the EditText
+                // https://console.firebase.google.com/u/0/project/spendesk-mobile/crashlytics/app/android:com.spendesk.spendesk/issues/366c950f3b688d79a5de9004b6c5e947?time=last-ninety-days&types=crash&versions=2.23.4%20(22302888);2.23.3%20(22302887)&sessionEventKey=6297C55100E60001732296088542CD65_1682809803838467563
+                // There is nothing much we can do here to get the text from the EditText if this method fails, so we just catch it to avoid a crash.
             }
         }
     })
 
+internal fun EditText.onTextChanged(consumer: (String) -> Unit) =
+    addTextChangedListener(object : TextWatcher {
+        override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
+
+        override fun onTextChanged(text: CharSequence?, p1: Int, p2: Int, p3: Int) {
+            text?.let { consumer(it.toString()) }
+        }
+
+        override fun afterTextChanged(editable: Editable?) {}
+    })
 
 fun EditText.setTextAndPositionCursorEnd(text: CharSequence) {
     setText(text)

--- a/library/src/main/java/com/spendesk/grapes/extensions/EditTextExtensions.kt
+++ b/library/src/main/java/com/spendesk/grapes/extensions/EditTextExtensions.kt
@@ -43,7 +43,17 @@ internal fun EditText.afterTextChangedWith(delay: Long, consumer: (String) -> Un
 
         override fun afterTextChanged(editable: Editable?) {
             timer.cancel()
-            timer = Timer().apply { schedule(delay) { editable?.let { consumer(it.toString()) } } }
+            timer = Timer().apply {
+                schedule(delay) {
+                    try {
+                        if (editable.isNullOrEmpty().not()) consumer(editable.toString())
+                    } catch (exception: IndexOutOfBoundsException) {
+                        // A crash randomly happens here causing an IndexOutOfBoundsException when toString() tries to get the characters from the EditText
+                        // https://console.firebase.google.com/u/0/project/spendesk-mobile/crashlytics/app/android:com.spendesk.spendesk/issues/366c950f3b688d79a5de9004b6c5e947?time=last-ninety-days&types=crash&versions=2.23.4%20(22302888);2.23.3%20(22302887)&sessionEventKey=6297C55100E60001732296088542CD65_1682809803838467563
+                        // There is nothing much we can do here to get the text from the EditText if this method fails, so we just catch it to avoid a crash.
+                    }
+                }
+            }
         }
     })
 


### PR DESCRIPTION
I didn't find any useful information about this crash. I don't know how to reproduce it, we don't have any info from the crash logs.
But from what I've been reading on Internet, it looks like it's quite random and might be a potential bug on Android when the text is empty: https://bugzilla.mozilla.org/show_bug.cgi?id=767791#c1
I've been looking at the source code where the crash happens ([SpannableStringBuilder.java](https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/text/SpannableStringBuilder.java)) and indeed, there is no check on the `mGapLength` when checking the range. 🤷 