### PR TITLE
Task/aa 1825 rework registration code view

### DIFF
--- a/library-compose/src/main/java/com/spendesk/grapes/compose/edittext/windowed/WindowEditText.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/edittext/windowed/WindowEditText.kt
@@ -1,0 +1,107 @@
+package com.spendesk.grapes.compose.edittext.windowed
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.spendesk.grapes.compose.theme.GrapesTheme
+
+/**
+ * @author Kélian CLERC
+ * @since 04/07/2022
+ */
+
+private const val DefaultMaxLength = 12
+private val ForbiddenCharRegex = "\\D".toRegex()
+
+
+@Composable
+fun WindowEditTextBase(
+    text: String,
+    onTextChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    maxLength: Int = DefaultMaxLength,
+    cursorColor: Color = GrapesTheme.colors.mainWhite,
+    textStyle: TextStyle = GrapesTheme.typography.bodyM.copy(letterSpacing = 3.sp, color = GrapesTheme.colors.mainWhite, fontSize = 18.sp, fontFeatureSettings = "tnum"),
+) {
+
+    val formattedText = sanitizeWindowedEditTextContent(text, maxLength)
+
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        BasicTextField(
+            value = formattedText,
+            onValueChange = { newValue ->
+                onTextChange(sanitizeWindowedEditTextContent(newValue, maxLength))
+            },
+            textStyle = textStyle,
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, autoCorrect = false),
+            cursorBrush = SolidColor(cursorColor),
+        )
+    }
+}
+
+private fun sanitizeWindowedEditTextContent(text: String, maxLength: Int): String {
+    return text.replace(ForbiddenCharRegex, "").run {
+        if (this.length > maxLength) {
+            this.substring(0 until maxLength)
+        } else {
+            this
+        }
+    }
+}
+
+@Preview
+@Composable
+fun WindowEditTextPreview() {
+    GrapesTheme {
+        var content by remember { mutableStateOf("") }
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(GrapesTheme.colors.mainPrimaryLight),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth()
+            ) {
+                Text(text = "Try to select this text to paste it in editText", color = GrapesTheme.colors.mainWhite)
+                Spacer(modifier = Modifier.size(4.dp))
+                SelectionContainer {
+                    Text(text = "1234-5678-9101", color = GrapesTheme.colors.mainWhite)
+                }
+                Spacer(modifier = Modifier.size(16.dp))
+                Text(text = "Text In edit text")
+                Text(text = content)
+            }
+            WindowEditTextBase(
+                text = content, onTextChange = { content = it }
+            )
+        }
+    }
+}

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/edittext/windowed/WindowEditText.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/edittext/windowed/WindowEditText.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -24,7 +25,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -39,9 +42,49 @@ private const val DefaultWindowLength = 4
 private const val DefaultMaxLength = 12
 private val ForbiddenCharRegex = "\\D".toRegex()
 
+@Composable
+fun WindowEditText(
+    text: String,
+    onTextChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    windowLength: Int = DefaultWindowLength,
+    maxLength: Int = DefaultMaxLength,
+    cursorColor: Color = GrapesTheme.colors.mainWhite,
+    textStyle: TextStyle = GrapesTheme.typography.bodyM.copy(letterSpacing = 3.sp, color = GrapesTheme.colors.mainWhite, fontSize = 18.sp, fontFeatureSettings = "tnum"),
+    hintChar: Char = '0',
+    separatorChar: Char = '-',
+) {
+    val hint = buildAnnotatedString {
+        withStyle(textStyle.toSpanStyle().copy(color = textStyle.color.copy(alpha = 0.2f))) {
+            append(hintChar)
+        }
+    }
+
+    val separator = buildAnnotatedString {
+        withStyle(textStyle.toSpanStyle().copy(letterSpacing = 38.sp)) {
+            append(separatorChar)
+        }
+    }
+
+    WindowEditTextBase(
+        text = text,
+        onTextChange = onTextChange,
+        modifier = modifier
+            .padding(16.dp)
+            .fillMaxWidth()
+            .background(GrapesTheme.colors.mainPrimaryDark, RoundedCornerShape(12.dp))
+            .padding(vertical = 16.dp),
+        windowLength = windowLength,
+        maxLength = maxLength,
+        cursorColor = cursorColor,
+        textStyle = textStyle,
+        hint = hint,
+        separator = separator
+    )
+}
 
 @Composable
-fun WindowEditTextBase(
+internal fun WindowEditTextBase(
     text: String,
     onTextChange: (String) -> Unit,
     modifier: Modifier = Modifier,
@@ -108,7 +151,7 @@ fun WindowEditTextPreview() {
                 Text(text = "Text In edit text")
                 Text(text = content)
             }
-            WindowEditTextBase(
+            WindowEditText(
                 text = content, onTextChange = { content = it }
             )
         }

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/edittext/windowed/WindowEditText.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/edittext/windowed/WindowEditText.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
@@ -34,6 +35,7 @@ import com.spendesk.grapes.compose.theme.GrapesTheme
  * @since 04/07/2022
  */
 
+private const val DefaultWindowLength = 4
 private const val DefaultMaxLength = 12
 private val ForbiddenCharRegex = "\\D".toRegex()
 
@@ -43,11 +45,17 @@ fun WindowEditTextBase(
     text: String,
     onTextChange: (String) -> Unit,
     modifier: Modifier = Modifier,
+    windowLength: Int = DefaultWindowLength,
     maxLength: Int = DefaultMaxLength,
     cursorColor: Color = GrapesTheme.colors.mainWhite,
     textStyle: TextStyle = GrapesTheme.typography.bodyM.copy(letterSpacing = 3.sp, color = GrapesTheme.colors.mainWhite, fontSize = 18.sp, fontFeatureSettings = "tnum"),
+    hint: AnnotatedString = AnnotatedString("0"),
+    separator: AnnotatedString = AnnotatedString("-"),
 ) {
 
+    val visualTransformation = remember(windowLength, maxLength, hint, separator, textStyle) {
+        WindowedVisualTransformation(windowLength = windowLength, originalStringMaxLength = maxLength, separation = separator, hintAnnotatedString = hint)
+    }
     val formattedText = sanitizeWindowedEditTextContent(text, maxLength)
 
     Box(modifier = modifier, contentAlignment = Alignment.Center) {
@@ -60,6 +68,7 @@ fun WindowEditTextBase(
             singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, autoCorrect = false),
             cursorBrush = SolidColor(cursorColor),
+            visualTransformation = visualTransformation
         )
     }
 }

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/edittext/windowed/WindowedOffsetMapping.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/edittext/windowed/WindowedOffsetMapping.kt
@@ -1,0 +1,38 @@
+package com.spendesk.grapes.compose.edittext.windowed
+
+import androidx.compose.ui.text.input.OffsetMapping
+import java.lang.Integer.min
+
+/**
+ * @author Kélian CLERC
+ * @since 21/07/2022
+ */
+class WindowedOffsetMapping(
+    private val originalStringMaxLength: Int,
+    private val windowLength: Int,
+    private val windowSeparatorLength: Int,
+) : OffsetMapping {
+
+    var currentLength: Int = 0
+
+    override fun originalToTransformed(offset: Int): Int {
+        val numberOfWindowSeparator = offset / windowLength
+        val separatorExtraOffset = if (offset == originalStringMaxLength) {
+            // Separators are only in between windows. If offset corresponds to the last char of original string, do not consider last separator
+            (numberOfWindowSeparator - 1) * windowSeparatorLength
+        } else {
+            numberOfWindowSeparator * windowSeparatorLength
+        }
+
+        // Transformed offset corresponds to original offset plus offset due to separators
+        return separatorExtraOffset + offset
+    }
+
+    override fun transformedToOriginal(offset: Int): Int {
+        val numberOfWindowSeparator = offset / (windowLength + windowSeparatorLength)
+        val separatorExtraOffset = numberOfWindowSeparator * windowSeparatorLength
+
+        // Prevents considering padding chars in offset calculation
+        return min(offset - separatorExtraOffset, currentLength)
+    }
+}

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/edittext/windowed/WindowedVisualTransformation.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/edittext/windowed/WindowedVisualTransformation.kt
@@ -1,0 +1,65 @@
+package com.spendesk.grapes.compose.edittext.windowed
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+
+/**
+ * @author Kélian CLERC
+ * @since 21/07/2022
+ */
+class WindowedVisualTransformation(
+    val windowLength: Int,
+    val originalStringMaxLength: Int,
+    val separation: AnnotatedString = AnnotatedString("-"),
+    val hintAnnotatedString: AnnotatedString = AnnotatedString(" "),
+) : VisualTransformation {
+    private val windowOffsetMapping = WindowedOffsetMapping(
+        originalStringMaxLength = originalStringMaxLength,
+        windowLength = windowLength,
+        windowSeparatorLength = separation.length
+    )
+
+    override fun filter(text: AnnotatedString): TransformedText {
+        val paddedString = if (text.length >= originalStringMaxLength) {
+            windowOffsetMapping.currentLength = originalStringMaxLength
+            text.subSequence(0, originalStringMaxLength)
+        } else {
+            windowOffsetMapping.currentLength = text.length
+
+            var paddedAnnotatedString = text
+            repeat(originalStringMaxLength - text.length) {
+                paddedAnnotatedString = paddedAnnotatedString.plus(hintAnnotatedString)
+            }
+            paddedAnnotatedString
+        }
+
+        val result = paddedString
+            .windowed(windowLength, windowLength)
+            .join(separation)
+
+        return TransformedText(result, windowOffsetMapping)
+    }
+
+    private fun AnnotatedString.windowed(size: Int, step: Int): List<AnnotatedString> {
+        val thisSize = this.length
+        val resultCapacity = thisSize / step + if (thisSize % step == 0) 0 else 1
+        val result = ArrayList<AnnotatedString>(resultCapacity)
+        var index = 0
+        while (index in 0 until thisSize) {
+            val end = index + size
+            result.add(this.subSequence(index, end))
+            index += step
+        }
+        return result
+    }
+
+    private fun List<AnnotatedString>.join(separationString: AnnotatedString? = null): AnnotatedString {
+        var result = if (this.isEmpty()) AnnotatedString("") else this.first()
+        for (index in 1 until this.size) {
+            separationString?.let { result = result.plus(separationString) }
+            result = result.plus(this[index])
+        }
+        return result
+    }
+}


### PR DESCRIPTION
I had to rework a bit the component to be able to do it in a compose way.
I can't yet use a composable to represent the separator. InlineTextContent is a good tool to do such things 
https://developer.android.com/reference/kotlin/androidx/compose/foundation/text/InlineTextContent
but it's not yet available in EditTexts
https://issuetracker.google.com/issues/205878141

https://user-images.githubusercontent.com/26220096/180201017-3d66d4e0-6dae-48af-a9eb-7e0ca8352120.mov

