### PR TITLE
Improve action message bottom sheet

### DIFF
--- a/library/src/main/java/com/spendesk/grapes/ActionMessageBottomSheetDialogFragment.kt
+++ b/library/src/main/java/com/spendesk/grapes/ActionMessageBottomSheetDialogFragment.kt
@@ -8,11 +8,16 @@ import android.view.ViewGroup
 import android.view.ViewTreeObserver.OnGlobalLayoutListener
 import android.widget.FrameLayout
 import androidx.annotation.DrawableRes
+import androidx.core.view.isVisible
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.spendesk.grapes.databinding.FragmentBottomSheetInfoBinding
-import com.spendesk.grapes.extensions.*
+import com.spendesk.grapes.extensions.getHeight
+import com.spendesk.grapes.extensions.gone
+import com.spendesk.grapes.extensions.visible
+import com.spendesk.grapes.extensions.visibleOrGone
+import com.spendesk.grapes.extensions.visibleWithTextOrGone
 
 /**
  * @author danyboucanova
@@ -27,7 +32,7 @@ open class ActionMessageBottomSheetDialogFragment : BottomSheetDialogFragment() 
     }
 
     data class Configuration(
-        @DrawableRes val imageResourceId: Int,
+        @DrawableRes val imageResourceId: Int? = null,
         val title: CharSequence,
         val description: CharSequence? = null,
         val primaryButtonText: CharSequence? = null,
@@ -89,7 +94,9 @@ open class ActionMessageBottomSheetDialogFragment : BottomSheetDialogFragment() 
     fun updateConfiguration(configuration: Configuration) {
         this.configuration = configuration
         binding?.apply {
-            actionMessageBottomSheetImage.setBackgroundResource(configuration.imageResourceId)
+            configuration.imageResourceId?.let { actionMessageBottomSheetImage.setBackgroundResource(it) }
+            actionMessageBottomSheetImage.isVisible = configuration.imageResourceId != null
+
             actionMessageBottomSheetTitleText.text = configuration.title
 
             actionMessageBottomSheetDescriptionText.visibleWithTextOrGone(configuration.description)

--- a/library/src/main/res/layout/fragment_bottom_sheet_info.xml
+++ b/library/src/main/res/layout/fragment_bottom_sheet_info.xml
@@ -47,7 +47,6 @@
         android:layout_marginStart="@dimen/actionMessageBottomSheetDescriptionMarginHorz"
         android:layout_marginTop="@dimen/actionMessageBottomSheetDescriptionMarginVert"
         android:layout_marginEnd="@dimen/actionMessageBottomSheetDescriptionMarginHorz"
-        android:layout_marginBottom="@dimen/actionMessageBottomSheetDescriptionMarginVert"
         android:ellipsize="end"
         app:layout_constrainedHeight="true"
         app:layout_constraintBottom_toTopOf="@id/actionMessageBottomSheetPrimaryButton"
@@ -62,6 +61,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/actionMessageBottomSheetPrimaryButtonMarginHorz"
+        android:layout_marginTop="@dimen/actionMessageBottomSheetPrimaryButtonMarginTop"
         android:layout_marginEnd="@dimen/actionMessageBottomSheetPrimaryButtonMarginHorz"
         app:layout_constraintBottom_toTopOf="@id/actionMessageBottomSheetSecondaryButton"
         app:layout_constraintEnd_toEndOf="parent"
@@ -81,5 +81,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/actionMessageBottomSheetPrimaryButton"
+        app:layout_goneMarginTop="@dimen/actionMessageBottomSheetPrimaryButtonMarginTop"
         tools:text="Secondary Button" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fix buttons margin when no description available

Before : (gray rectangles represent buttons)
![Capture d’écran 2022-12-06 à 09 41 17](https://user-images.githubusercontent.com/26220096/205863303-33ba8643-9daf-48bb-acaa-0cdeaaa8dd43.png)

After 
![Capture d’écran 2022-12-06 à 09 41 08](https://user-images.githubusercontent.com/26220096/205863436-740d56d8-0daf-4f94-9b1c-98fbce3c0315.png)


Add possibility to remove image from bottom sheet