### PR TITLE
feat(compose) Add TopAppBar composable

### DIFF
--- a/library-compose/src/main/java/com/spendesk/grapes/compose/appbar/GrapesTopAppBar.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/appbar/GrapesTopAppBar.kt
@@ -1,0 +1,229 @@
+package com.spendesk.grapes.compose.appbar
+
+import android.util.Log
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.spendesk.grapes.compose.R
+import com.spendesk.grapes.compose.theme.GrapesTheme
+
+/**
+ * @author jean-philippe
+ * @since 28/12/2022, Wed
+ **/
+
+@Composable
+fun GrapesTopAppBar(
+    title: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    navigationIcon: @Composable (() -> Unit)? = null,
+    actions: @Composable RowScope.() -> Unit = {},
+) {
+    TopAppBar(
+        modifier = modifier,
+        title = title,
+        contentColor = GrapesTheme.colors.mainBlack,
+        backgroundColor = GrapesTheme.colors.mainWhite,
+        navigationIcon = navigationIcon,
+        actions = actions,
+        elevation = GrapesTheme.dimensions.elevationNormal
+    )
+}
+
+@Composable
+fun GrapesTopAppBarTitle(
+    title: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        modifier = modifier,
+        text = title,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis,
+        style = GrapesTheme.typography.titleL,
+    )
+}
+
+@Composable
+fun GrapesTopAppBarTitleWithSubtitle(
+    title: String,
+    subTitle: String,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        GrapesTopAppBarTitle(
+            title = title,
+        )
+
+        Text(
+            text = subTitle,
+            lineHeight = GrapesTheme.typography.bodyS.fontSize,
+            style = GrapesTheme.typography.bodyS,
+        )
+    }
+}
+
+@Composable
+fun GrapesTopAppBarIconButton(
+    icon: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {}
+) {
+    IconButton(
+        modifier = modifier,
+        content = icon,
+        onClick = onClick,
+    )
+}
+
+@Composable
+fun GrapesTopAppBarBackIcon(
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        modifier = modifier.size(24.dp),
+        imageVector = ImageVector.vectorResource(R.drawable.ic_arrow_back),
+        contentDescription = stringResource(id = R.string.grapes_top_app_bar_back_icon_description),
+    )
+}
+
+@Composable
+fun GrapesTopAppBarMoreIcon(
+    modifier: Modifier = Modifier,
+) {
+    Icon(
+        modifier = modifier.size(24.dp),
+        imageVector = ImageVector.vectorResource(R.drawable.ic_more_vertical),
+        contentDescription = stringResource(id = R.string.grapes_top_app_bar_more_icon_description),
+    )
+}
+
+//region previews
+@Preview
+@Composable
+fun GrapesSimpleTopAppBarPreview() {
+    GrapesTheme {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(GrapesTheme.colors.mainNeutralLighter)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            GrapesTopAppBar(
+                modifier = Modifier.fillMaxWidth(),
+                title = { GrapesTopAppBarTitle(title = "Top app bar title") },
+            )
+
+            GrapesTopAppBar(
+                modifier = Modifier.fillMaxWidth(),
+                title = { GrapesTopAppBarTitle(title = "Top app bar  with a very very very very very very very long title") },
+            )
+
+            GrapesTopAppBar(
+                modifier = Modifier.fillMaxWidth(),
+                title = {
+                    GrapesTopAppBarTitleWithSubtitle(
+                        title = "Top app bar title",
+                        subTitle = "Top app bar subtitle"
+                    )
+                },
+            )
+
+            GrapesTopAppBar(
+                modifier = Modifier.fillMaxWidth(),
+                title = { GrapesTopAppBarTitle(title = "Top app bar title") },
+                navigationIcon = {
+                    GrapesTopAppBarIconButton(
+                        icon = { GrapesTopAppBarBackIcon() },
+                        onClick = { Log.i("GrapesTopAppBar", "navigationIcon click") }
+                    )
+                },
+            )
+
+            GrapesTopAppBar(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                title = {
+                    GrapesTopAppBarTitle(title = "Top app bar  with a very very very very very very very long title")
+                },
+                navigationIcon = {
+                    GrapesTopAppBarIconButton(
+                        icon = { GrapesTopAppBarBackIcon() },
+                        onClick = { Log.i("GrapesTopAppBar", "navigationIcon click") }
+                    )
+                },
+            )
+
+            GrapesTopAppBar(
+                modifier = Modifier.fillMaxWidth(),
+                title = {
+                    GrapesTopAppBarTitleWithSubtitle(
+                        title = "Top app bar title",
+                        subTitle = "Top app bar subtitle"
+                    )
+                },
+                navigationIcon = {
+                    GrapesTopAppBarIconButton(
+                        icon = { GrapesTopAppBarBackIcon() },
+                        onClick = { Log.i("GrapesTopAppBar", "navigationIcon click") }
+                    )
+                },
+            )
+
+            GrapesTopAppBar(
+                modifier = Modifier.fillMaxWidth(),
+                title = { GrapesTopAppBarTitle(title = "Top app bar title") },
+                navigationIcon = {
+                    GrapesTopAppBarIconButton(
+                        icon = { GrapesTopAppBarBackIcon() },
+                        onClick = { Log.i("GrapesTopAppBar", "navigationIcon click") }
+                    )
+                },
+                actions = {
+                    GrapesTopAppBarIconButton(
+                        icon = { GrapesTopAppBarMoreIcon() },
+                        onClick = { Log.i("GrapesTopAppBar", "action button click") }
+                    )
+                },
+            )
+
+            GrapesTopAppBar(
+                modifier = Modifier.fillMaxWidth(),
+                title = {
+                    GrapesTopAppBarTitleWithSubtitle(
+                        title = "Top app bar title",
+                        subTitle = "Top app bar subtitle"
+                    )
+                },
+                navigationIcon = {
+                    GrapesTopAppBarIconButton(
+                        icon = { GrapesTopAppBarBackIcon() },
+                        onClick = { Log.i("GrapesTopAppBar", "navigationIcon click") }
+                    )
+                },
+                actions = {
+                    GrapesTopAppBarIconButton(
+                        icon = { GrapesTopAppBarMoreIcon() },
+                        onClick = { Log.i("GrapesTopAppBar", "action button click") }
+                    )
+                },
+            )
+        }
+    }
+}
+//endregion previews

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/theme/Dimensions.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/theme/Dimensions.kt
@@ -17,7 +17,9 @@ data class GrapesDimensions(
     val paddingNormal: Dp = 16.dp,
     val paddingLarge: Dp = 24.dp,
 
-    val radiusNormal: Dp = 8.dp
+    val radiusNormal: Dp = 8.dp,
+
+    val elevationNormal: Dp = 8.dp,
 )
 
 internal val LocalGrapesDimensions = staticCompositionLocalOf { GrapesDimensions() }

--- a/library-compose/src/main/res/drawable/ic_arrow_back.xml
+++ b/library-compose/src/main/res/drawable/ic_arrow_back.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:tint="@android:color/black"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z" />
+</vector>

--- a/library-compose/src/main/res/drawable/ic_more_vertical.xml
+++ b/library-compose/src/main/res/drawable/ic_more_vertical.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM12,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z"/>
+</vector>

--- a/library-compose/src/main/res/values/grapes_strings.xml
+++ b/library-compose/src/main/res/values/grapes_strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="grapes_top_app_bar_back_icon_description">Back</string>
+    <string name="grapes_top_app_bar_more_icon_description">More</string>
+
+</resources>


### PR DESCRIPTION
# TopAppBar

## Composable

### GrapesTopAppBar

![Screenshot 2022-12-29 at 23 06 43](https://user-images.githubusercontent.com/112860634/210015511-a426e217-b544-4a91-b60d-e07452257558.png)

#### Code
```kotlin
GrapesTopAppBar(
  modifier = Modifier.fillMaxWidth(),
  title = {
    GrapesTopAppBarTitleWithSubtitle(
      title = "Top app bar title",
      subTitle = "Top app bar subtitle"
    )
  },
  navigationIcon = {
    GrapesTopAppBarIconButton(
      icon = {
        GrapesTopAppBarBackIcon()
      },
      onClick = {
        Log.i("GrapesTopAppBar", "navigationIcon click")
      }
    )
  },
  actions = {
    GrapesTopAppBarIconButton(
      icon = {
        GrapesTopAppBarMoreIcon()
      },
      onClick = {
        Log.i("GrapesTopAppBar", "action button click")
      }
    )
  },
)
```
