### PR TITLE
Fix SummaryBlockContentTitle overlap

### DIFF
--- a/library/src/main/res/layout/summary_block_content_title.xml
+++ b/library/src/main/res/layout/summary_block_content_title.xml
@@ -10,43 +10,42 @@
         style="@style/SummaryBlockContentTitleStartText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        app:layout_constrainedWidth="true"
+        app:layout_goneMarginEnd="@dimen/inlineBlockViewTextMarginHorz"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/summaryBlockContentTitleMiddleText"
+        app:layout_constraintHorizontal_chainStyle="packed"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintHorizontal_bias="0"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="This is a title" />
+        tools:text="This is a title which is very very very long and that takes a lotof " />
 
     <TextView
         android:id="@+id/summaryBlockContentTitleMiddleText"
         style="@style/SummaryBlockContentTitleMiddleText"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/summaryBlockContentMiddleTitleTextMarginStart"
+        android:layout_marginEnd="@dimen/inlineBlockViewTextMarginHorz"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/summaryBlockContentTitleEndLeftBarrier"
+        app:layout_constraintEnd_toStartOf="@id/summaryBlockContentTitleEndText"
         app:layout_constraintStart_toEndOf="@id/summaryBlockContentTitleStartText"
+        app:layout_constraintHorizontal_bias="0"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="• Optional"
         tools:visibility="visible" />
-
-    <androidx.constraintlayout.widget.Barrier
-        android:id="@+id/summaryBlockContentTitleEndLeftBarrier"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:barrierDirection="start"
-        app:constraint_referenced_ids="summaryBlockContentTitleEndText" />
 
     <TextView
         android:id="@+id/summaryBlockContentTitleEndText"
         style="@style/SummaryBlockContentTitleEndText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/partialContentBlockTextEndMarginEnd"
         android:layout_marginStart="@dimen/inlineBlockViewTextMarginHorz"
+        android:layout_marginEnd="@dimen/partialContentBlockTextEndMarginEnd"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/summaryBlockContentTitleEndRightBarrier"
-        app:layout_constraintStart_toEndOf="@+id/summaryBlockContentTitleEndLeftBarrier"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_goneMarginStart="@dimen/inlineBlockViewTextMarginHorz"
         tools:text="Action"
         tools:visibility="visible" />
 
@@ -54,8 +53,8 @@
         android:id="@+id/summaryBlockContentTitleEndRightBarrier"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:barrierDirection="end"
-        app:constraint_referenced_ids="summaryBlockContentTitleEndText" />
+        app:barrierDirection="start"
+        app:constraint_referenced_ids="summaryBlockContentTitleEndImage, summaryBlockContentTitleEndProgressBar" />
 
     <ImageView
         android:id="@+id/summaryBlockContentTitleEndImage"
@@ -64,7 +63,6 @@
         android:layout_height="@dimen/partialContentBlockEndImageSize"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/summaryBlockContentTitleEndRightBarrier"
         app:layout_constraintTop_toTopOf="parent"
         tools:visibility="visible" />
 
@@ -75,7 +73,6 @@
         android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/summaryBlockContentTitleEndRightBarrier"
         app:layout_constraintTop_toTopOf="parent"
         tools:visibility="visible" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/ContentsFragment.kt
+++ b/sample/src/main/java/com/spendesk/grapes/samples/home/fragments/ContentsFragment.kt
@@ -191,7 +191,7 @@ class ContentsFragment : Fragment(R.layout.fragment_home_contents) {
             updateConfiguration(
                 configuration = SummaryBlockContentTextView.Configuration(
                     titleConfiguration = SummaryBlockTitleView.Configuration(
-                        startTitle = "Description",
+                        startTitle = "Very very long Description to see what's happening when the description is long",
                         endTitle = "Add",
                         isActivated = true
                     )


### PR DESCRIPTION
Before
<img width="409" alt="Capture d’écran 2023-01-05 à 16 40 13" src="https://user-images.githubusercontent.com/26220096/210820802-54e14033-6929-4e9b-8c4a-9255cdd3f38e.png">

After
<img width="394" alt="Capture d’écran 2023-01-05 à 16 38 08" src="https://user-images.githubusercontent.com/26220096/210820828-5ba5391e-2eb6-46a8-8d9b-570b98189b82.png">
