### PR TITLE
Feat(Compose) Add GrapesTextInput 

### DIFF
--- a/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/GrapesBaseTextField.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/GrapesBaseTextField.kt
@@ -1,0 +1,133 @@
+package com.spendesk.grapes.compose.textfield
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Text
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
+import com.spendesk.grapes.compose.theme.GrapesTheme
+
+/**
+ * @author jean-philippe
+ * @since 06/01/2023, Fri
+ **/
+
+@ExperimentalMaterialApi
+@Composable
+internal fun GrapesBaseTextField(
+    value: TextFieldValue,
+    placeholderValue: String,
+    onValueChange: (TextFieldValue) -> Unit,
+    modifier: Modifier = Modifier,
+    helperText: String? = null,
+    enabled: Boolean = true,
+    textStyle: TextStyle = GrapesTheme.typography.bodyRegular,
+    isError: Boolean = false,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    singleLine: Boolean = false,
+    colors: GrapesTextFieldColors = GrapesTextFieldDefaults.textFieldColors(),
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+) {
+    val textColor = colors.textColor(enabled).value
+    val mergedTextStyle = textStyle.merge(TextStyle(color = textColor))
+
+    GrapesCoreTextField(
+        value = value,
+        placeholderValue = placeholderValue,
+        onValueChange = onValueChange,
+        modifier = Modifier,
+        enabled = enabled,
+        textStyle = mergedTextStyle,
+        isError = isError,
+        keyboardActions = keyboardActions,
+        keyboardOptions = keyboardOptions,
+        singleLine = singleLine,
+        colors = colors,
+        visualTransformation = visualTransformation,
+        interactionSource = interactionSource
+    )
+}
+
+@ExperimentalMaterialApi
+@Composable
+private fun GrapesCoreTextField(
+    value: TextFieldValue,
+    placeholderValue: String,
+    onValueChange: (TextFieldValue) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    textStyle: TextStyle = TextStyle.Default,
+    isError: Boolean = false,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    singleLine: Boolean = false,
+    colors: GrapesTextFieldColors = GrapesTextFieldDefaults.textFieldColors(),
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+) {
+    BasicTextField(
+        modifier = modifier
+            .defaultMinSize(
+                minWidth = GrapesTextFieldDefaults.MinWidth,
+                minHeight = GrapesTextFieldDefaults.MinHeight,
+            )
+            .shadow(
+                elevation = GrapesTextFieldDefaults.Elevation,
+                shape = GrapesTextFieldDefaults.TextFieldShape,
+            )
+            .background(
+                color = colors.backgroundColor(enabled).value,
+                shape = GrapesTextFieldDefaults.TextFieldShape
+            ),
+        enabled = enabled,
+        value = value,
+        onValueChange = onValueChange,
+        textStyle = textStyle,
+        cursorBrush = SolidColor(colors.cursorColor(isError).value),
+        visualTransformation = visualTransformation,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        interactionSource = interactionSource,
+        singleLine = singleLine,
+        decorationBox = @Composable { innerTextField ->
+            TextFieldDefaults.OutlinedTextFieldDecorationBox(
+                value = value.text,
+                innerTextField = innerTextField,
+                enabled = enabled,
+                singleLine = singleLine,
+                visualTransformation = visualTransformation,
+                interactionSource = interactionSource,
+                contentPadding = GrapesTextFieldDefaults.textFieldPadding(),
+                placeholder = {
+                    Text(
+                        text = placeholderValue,
+                        style = GrapesTheme.typography.bodyRegular,
+                        color = colors.placeholderColor(enabled = enabled).value,
+                    )
+                },
+                border = {
+                    GrapesTextFieldDefaults.BorderBox(
+                        enabled = enabled,
+                        isError = isError,
+                        interactionSource = interactionSource,
+                        colors = colors
+                    )
+                }
+            )
+        }
+    )
+}

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/GrapesBaseTextField.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/GrapesBaseTextField.kt
@@ -2,7 +2,17 @@ package com.spendesk.grapes.compose.textfield
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.paddingFromBaseline
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -14,6 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
@@ -42,24 +53,71 @@ internal fun GrapesBaseTextField(
     visualTransformation: VisualTransformation = VisualTransformation.None,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
 ) {
+
     val textColor = colors.textColor(enabled).value
     val mergedTextStyle = textStyle.merge(TextStyle(color = textColor))
 
-    GrapesCoreTextField(
-        value = value,
-        placeholderValue = placeholderValue,
-        onValueChange = onValueChange,
-        modifier = Modifier,
-        enabled = enabled,
-        textStyle = mergedTextStyle,
-        isError = isError,
-        keyboardActions = keyboardActions,
-        keyboardOptions = keyboardOptions,
-        singleLine = singleLine,
-        colors = colors,
-        visualTransformation = visualTransformation,
-        interactionSource = interactionSource
-    )
+    Column(
+        modifier = modifier.width(IntrinsicSize.Min)
+    ) {
+        GrapesCoreTextField(
+            value = value,
+            placeholderValue = placeholderValue,
+            modifier = Modifier,
+            onValueChange = onValueChange,
+            enabled = enabled,
+            textStyle = mergedTextStyle,
+            isError = isError,
+            keyboardActions = keyboardActions,
+            keyboardOptions = keyboardOptions,
+            singleLine = singleLine,
+            colors = colors,
+            visualTransformation = visualTransformation,
+            interactionSource = interactionSource
+        )
+
+        if (helperText != null && helperText.isNotEmpty()) {
+            GrapesHelperText(
+                text = helperText,
+                modifier = Modifier.fillMaxWidth(),
+                enabled = enabled,
+                isError = isError
+            )
+        }
+    }
+}
+
+@Composable
+internal fun GrapesHelperText(
+    text: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    textStyle: TextStyle = GrapesTheme.typography.bodyXs,
+    isError: Boolean = false,
+    colors: GrapesTextFieldColors = GrapesTextFieldDefaults.textFieldColors(),
+    contentPadding: PaddingValues = GrapesTextFieldDefaults.textFieldPadding(),
+) {
+    val textColor = colors.helperTextColor(enabled, isError).value
+    val mergedTextStyle = textStyle.merge(TextStyle(color = textColor))
+
+    val layoutDirection = LocalLayoutDirection.current
+
+    val topPadding = contentPadding.calculateTopPadding()
+    val endPadding = contentPadding.calculateEndPadding(layoutDirection)
+    val startPadding = contentPadding.calculateStartPadding(layoutDirection)
+
+    Box(
+        modifier = modifier
+            .padding(start = startPadding, end = endPadding),
+        propagateMinConstraints = true,
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier
+                .paddingFromBaseline(top = topPadding),
+            style = mergedTextStyle,
+        )
+    }
 }
 
 @ExperimentalMaterialApi
@@ -81,6 +139,7 @@ private fun GrapesCoreTextField(
 ) {
     BasicTextField(
         modifier = modifier
+            .fillMaxWidth()
             .defaultMinSize(
                 minWidth = GrapesTextFieldDefaults.MinWidth,
                 minHeight = GrapesTextFieldDefaults.MinHeight,

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/GrapesTextFieldDefaults.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/GrapesTextFieldDefaults.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material.ContentAlpha
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.TextFieldColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
@@ -30,7 +29,6 @@ import com.spendesk.grapes.compose.theme.GrapesTheme
  * @author jean-philippe
  * @since 09/01/2023, Mon
  **/
-@ExperimentalMaterialApi
 @Immutable
 object GrapesTextFieldDefaults {
     private val TextFieldPaddingVertical = 14.dp
@@ -114,7 +112,10 @@ object GrapesTextFieldDefaults {
         disabledLabelColor: Color = unfocusedLabelColor.copy(ContentAlpha.disabled), // Todo replace
         errorLabelColor: Color = GrapesTheme.colors.mainAlertNormal,
         placeholderColor: Color = GrapesTheme.colors.mainNeutralDark,
-        disabledPlaceholderColor: Color = GrapesTheme.colors.mainNeutralNormal
+        disabledPlaceholderColor: Color = GrapesTheme.colors.mainNeutralNormal,
+        helperTextColor: Color = GrapesTheme.colors.mainNeutralDark,
+        errorHelperTextColor: Color = GrapesTheme.colors.mainAlertNormal,
+        disabledHelperTextColor: Color = helperTextColor.copy(ContentAlpha.disabled),
     ): GrapesTextFieldColors = DefaultGrapesGrapesTextFieldColors(
         textColor = textColor,
         disabledTextColor = disabledTextColor,
@@ -136,7 +137,10 @@ object GrapesTextFieldDefaults {
         disabledLabelColor = disabledLabelColor,
         errorLabelColor = errorLabelColor,
         placeholderColor = placeholderColor,
-        disabledPlaceholderColor = disabledPlaceholderColor
+        disabledPlaceholderColor = disabledPlaceholderColor,
+        helperTextColor = helperTextColor,
+        errorHelperTextColor = errorHelperTextColor,
+        disabledHelperTextColor = disabledHelperTextColor,
     )
 }
 
@@ -162,11 +166,25 @@ private data class DefaultGrapesGrapesTextFieldColors(
     private val disabledLabelColor: Color,
     private val errorLabelColor: Color,
     private val placeholderColor: Color,
-    private val disabledPlaceholderColor: Color
+    private val disabledPlaceholderColor: Color,
+    private val helperTextColor: Color,
+    private val disabledHelperTextColor: Color,
+    private val errorHelperTextColor: Color,
 ) : GrapesTextFieldColors {
 
     companion object {
         private const val AnimationDuration = 150
+    }
+
+    @Composable
+    override fun helperTextColor(enabled: Boolean, isError: Boolean): State<Color> {
+        return rememberUpdatedState(
+            when {
+                !enabled -> disabledHelperTextColor
+                isError -> errorHelperTextColor
+                else -> helperTextColor
+            }
+        )
     }
 
     @Composable
@@ -256,5 +274,6 @@ private data class DefaultGrapesGrapesTextFieldColors(
 @Stable
 interface GrapesTextFieldColors : TextFieldColors {
 
-    // TODO add helper text color
+    @Composable
+    fun helperTextColor(enabled: Boolean, isError: Boolean): State<Color>
 }

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/GrapesTextFieldDefaults.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/GrapesTextFieldDefaults.kt
@@ -1,0 +1,260 @@
+package com.spendesk.grapes.compose.textfield
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.TextFieldColors
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.spendesk.grapes.compose.theme.GrapesTheme
+
+/**
+ * @author jean-philippe
+ * @since 09/01/2023, Mon
+ **/
+@ExperimentalMaterialApi
+@Immutable
+object GrapesTextFieldDefaults {
+    private val TextFieldPaddingVertical = 14.dp
+    private val TextFieldPaddingHorizontal = 16.dp
+
+    private val BorderThickness = 0.5.dp
+
+    val MinWidth = 344.dp
+    val MinHeight = 48.dp
+
+    val Elevation = 1.dp
+
+    val TextFieldShape: Shape
+        @Composable
+        @ReadOnlyComposable
+        get() = GrapesTheme.shapes.small
+
+
+    fun textFieldPadding(
+        start: Dp = TextFieldPaddingVertical,
+        top: Dp = TextFieldPaddingHorizontal,
+        end: Dp = TextFieldPaddingHorizontal,
+        bottom: Dp = TextFieldPaddingVertical
+    ): PaddingValues = PaddingValues(start, top, end, bottom)
+
+    @Composable
+    fun BorderBox(
+        enabled: Boolean,
+        isError: Boolean,
+        interactionSource: InteractionSource,
+        colors: TextFieldColors,
+        shape: Shape = TextFieldShape,
+    ) {
+        val borderStroke = rememberBorderStrokeState(
+            enabled = enabled,
+            isError = isError,
+            interactionSource = interactionSource,
+            colors = colors
+        )
+
+        Box(
+            Modifier
+                .border(borderStroke.value, shape)
+        )
+    }
+
+    @Composable
+    private fun rememberBorderStrokeState(
+        enabled: Boolean,
+        isError: Boolean,
+        interactionSource: InteractionSource,
+        colors: TextFieldColors,
+        borderThickness: Dp = BorderThickness,
+    ): State<BorderStroke> {
+        val indicatorColor = colors.indicatorColor(enabled, isError, interactionSource)
+
+        return rememberUpdatedState(
+            BorderStroke(borderThickness, SolidColor(indicatorColor.value))
+        )
+    }
+
+    @Composable
+    fun textFieldColors(
+        textColor: Color = GrapesTheme.colors.mainNeutralDarkest,
+        disabledTextColor: Color = textColor.copy(ContentAlpha.disabled),
+        backgroundColor: Color = GrapesTheme.colors.mainWhite,
+        cursorColor: Color = GrapesTheme.colors.mainPrimaryLight,
+        errorCursorColor: Color = GrapesTheme.colors.mainAlertNormal,
+        focusedBorderColor: Color = GrapesTheme.colors.mainNeutralLight,
+        unfocusedBorderColor: Color = GrapesTheme.colors.mainNeutralLight,
+        disabledBorderColor: Color = GrapesTheme.colors.mainNeutralLighter,
+        errorBorderColor: Color = GrapesTheme.colors.mainAlertNormal,
+        leadingIconColor: Color = Color.Yellow, // Todo replace
+        disabledLeadingIconColor: Color = Color.Yellow, // Todo replace
+        errorLeadingIconColor: Color = leadingIconColor, // Todo replace
+        trailingIconColor: Color = Color.Yellow, // Todo replace
+        disabledTrailingIconColor: Color = trailingIconColor.copy(alpha = ContentAlpha.disabled), // Todo replace
+        errorTrailingIconColor: Color = Color.Yellow, // Todo replace
+        focusedLabelColor: Color = Color.Yellow, // Todo replace
+        unfocusedLabelColor: Color = Color.Yellow, // Todo replace
+        disabledLabelColor: Color = unfocusedLabelColor.copy(ContentAlpha.disabled), // Todo replace
+        errorLabelColor: Color = GrapesTheme.colors.mainAlertNormal,
+        placeholderColor: Color = GrapesTheme.colors.mainNeutralDark,
+        disabledPlaceholderColor: Color = GrapesTheme.colors.mainNeutralNormal
+    ): GrapesTextFieldColors = DefaultGrapesGrapesTextFieldColors(
+        textColor = textColor,
+        disabledTextColor = disabledTextColor,
+        cursorColor = cursorColor,
+        errorCursorColor = errorCursorColor,
+        focusedIndicatorColor = focusedBorderColor,
+        unfocusedIndicatorColor = unfocusedBorderColor,
+        errorIndicatorColor = errorBorderColor,
+        disabledIndicatorColor = disabledBorderColor,
+        leadingIconColor = leadingIconColor,
+        disabledLeadingIconColor = disabledLeadingIconColor,
+        errorLeadingIconColor = errorLeadingIconColor,
+        trailingIconColor = trailingIconColor,
+        disabledTrailingIconColor = disabledTrailingIconColor,
+        errorTrailingIconColor = errorTrailingIconColor,
+        backgroundColor = backgroundColor,
+        focusedLabelColor = focusedLabelColor,
+        unfocusedLabelColor = unfocusedLabelColor,
+        disabledLabelColor = disabledLabelColor,
+        errorLabelColor = errorLabelColor,
+        placeholderColor = placeholderColor,
+        disabledPlaceholderColor = disabledPlaceholderColor
+    )
+}
+
+@Immutable
+private data class DefaultGrapesGrapesTextFieldColors(
+    private val textColor: Color,
+    private val disabledTextColor: Color,
+    private val cursorColor: Color,
+    private val errorCursorColor: Color,
+    private val focusedIndicatorColor: Color,
+    private val unfocusedIndicatorColor: Color,
+    private val errorIndicatorColor: Color,
+    private val disabledIndicatorColor: Color,
+    private val leadingIconColor: Color,
+    private val disabledLeadingIconColor: Color,
+    private val errorLeadingIconColor: Color,
+    private val trailingIconColor: Color,
+    private val disabledTrailingIconColor: Color,
+    private val errorTrailingIconColor: Color,
+    private val backgroundColor: Color,
+    private val focusedLabelColor: Color,
+    private val unfocusedLabelColor: Color,
+    private val disabledLabelColor: Color,
+    private val errorLabelColor: Color,
+    private val placeholderColor: Color,
+    private val disabledPlaceholderColor: Color
+) : GrapesTextFieldColors {
+
+    companion object {
+        private const val AnimationDuration = 150
+    }
+
+    @Composable
+    override fun leadingIconColor(enabled: Boolean, isError: Boolean): State<Color> {
+        return rememberUpdatedState(
+            when {
+                !enabled -> disabledLeadingIconColor
+                isError -> errorLeadingIconColor
+                else -> leadingIconColor
+            }
+        )
+    }
+
+    @Composable
+    override fun trailingIconColor(enabled: Boolean, isError: Boolean): State<Color> {
+        return rememberUpdatedState(
+            when {
+                !enabled -> disabledTrailingIconColor
+                isError -> errorTrailingIconColor
+                else -> trailingIconColor
+            }
+        )
+    }
+
+    @Composable
+    override fun indicatorColor(
+        enabled: Boolean,
+        isError: Boolean,
+        interactionSource: InteractionSource
+    ): State<Color> {
+        val focused by interactionSource.collectIsFocusedAsState()
+
+        val targetValue = when {
+            !enabled -> disabledIndicatorColor
+            isError -> errorIndicatorColor
+            focused -> focusedIndicatorColor
+            else -> unfocusedIndicatorColor
+        }
+        return if (enabled) {
+            animateColorAsState(targetValue, tween(durationMillis = AnimationDuration))
+        } else {
+            rememberUpdatedState(targetValue)
+        }
+    }
+
+    @Composable
+    override fun backgroundColor(enabled: Boolean): State<Color> {
+        return rememberUpdatedState(backgroundColor)
+    }
+
+    @Composable
+    override fun placeholderColor(enabled: Boolean): State<Color> {
+        return rememberUpdatedState(if (enabled) placeholderColor else disabledPlaceholderColor)
+    }
+
+    @Composable
+    override fun labelColor(
+        enabled: Boolean,
+        error: Boolean,
+        interactionSource: InteractionSource
+    ): State<Color> {
+        val focused by interactionSource.collectIsFocusedAsState()
+
+        val targetValue = when {
+            !enabled -> disabledLabelColor
+            error -> errorLabelColor
+            focused -> focusedLabelColor
+            else -> unfocusedLabelColor
+        }
+        return rememberUpdatedState(targetValue)
+    }
+
+    @Composable
+    override fun textColor(enabled: Boolean): State<Color> {
+        return rememberUpdatedState(if (enabled) textColor else disabledTextColor)
+    }
+
+    @Composable
+    override fun cursorColor(isError: Boolean): State<Color> {
+        return rememberUpdatedState(if (isError) errorCursorColor else cursorColor)
+    }
+}
+
+/**
+ * Represent the colors of a the input text
+ */
+@Stable
+interface GrapesTextFieldColors : TextFieldColors {
+
+    // TODO add helper text color
+}

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/GrapesTextInput.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/GrapesTextInput.kt
@@ -1,0 +1,139 @@
+package com.spendesk.grapes.compose.textfield
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.spendesk.grapes.compose.theme.GrapesTheme
+
+/**
+ * @author jean-philippe
+ * @since 05/01/2023, Thu
+ **/
+@ExperimentalMaterialApi
+@Composable
+fun GrapesTextInput(
+    value: TextFieldValue,
+    placeholderValue: String,
+    onValueChange: (TextFieldValue) -> Unit,
+    modifier: Modifier = Modifier,
+    helperText: String? = null,
+    enabled: Boolean = true,
+    textStyle: TextStyle = GrapesTheme.typography.bodyRegular,
+    colors: GrapesTextFieldColors = GrapesTextFieldDefaults.textFieldColors(),
+    isError: Boolean = false,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+) {
+    GrapesBaseTextField(
+        value = value,
+        placeholderValue = placeholderValue,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        enabled = enabled,
+        textStyle = textStyle,
+        colors = colors,
+        isError = isError,
+        keyboardActions = keyboardActions,
+        keyboardOptions = keyboardOptions,
+        singleLine = true,
+        visualTransformation = visualTransformation,
+    )
+}
+
+// region: Preview
+
+@ExperimentalMaterialApi
+@Composable
+@Preview
+fun PreviewGrapesTextField() {
+    var emptyTextFieldValue by remember {
+        mutableStateOf(
+            TextFieldValue(
+                text = ""
+            )
+        )
+    }
+
+    var filledTextFieldValue by remember {
+        mutableStateOf(
+            TextFieldValue(
+                text = "This is a text value"
+            )
+        )
+    }
+
+    var disabledTextFieldValue by remember {
+        mutableStateOf(
+            TextFieldValue(
+                text = "This is a disabled text value"
+            )
+        )
+    }
+
+    GrapesTheme {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(GrapesTheme.colors.mainBackground)
+                .verticalScroll(rememberScrollState())
+                .padding(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+
+            GrapesTextInput(
+                modifier = Modifier.fillMaxSize(),
+                value = emptyTextFieldValue,
+                placeholderValue = "This is a placeholder",
+                onValueChange = {
+                    emptyTextFieldValue = it
+                }
+            )
+
+            GrapesTextInput(
+                modifier = Modifier.fillMaxSize(),
+                value = filledTextFieldValue,
+                isError = true,
+                placeholderValue = "This is a placeholder",
+                onValueChange = {
+                    filledTextFieldValue = it
+                }
+            )
+
+            GrapesTextInput(
+                modifier = Modifier.fillMaxSize(),
+                value = emptyTextFieldValue,
+                enabled = false,
+                placeholderValue = "This is a disabled placeholder",
+                onValueChange = {
+                    emptyTextFieldValue = it
+                }
+            )
+
+            GrapesTextInput(
+                modifier = Modifier.fillMaxSize(),
+                value = disabledTextFieldValue,
+                enabled = false,
+                placeholderValue = "This is a placeholder",
+                onValueChange = {
+                    disabledTextFieldValue = it
+                }
+            )
+        }
+    }
+}
+// endregion: Preview

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/GrapesTextInput.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/GrapesTextInput.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
@@ -44,6 +45,7 @@ fun GrapesTextInput(
         placeholderValue = placeholderValue,
         onValueChange = onValueChange,
         modifier = modifier,
+        helperText = helperText,
         enabled = enabled,
         textStyle = textStyle,
         colors = colors,
@@ -92,30 +94,33 @@ fun PreviewGrapesTextField() {
                 .background(GrapesTheme.colors.mainBackground)
                 .verticalScroll(rememberScrollState())
                 .padding(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
 
             GrapesTextInput(
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier,
                 value = emptyTextFieldValue,
                 placeholderValue = "This is a placeholder",
+                helperText = "This is helper text",
                 onValueChange = {
                     emptyTextFieldValue = it
                 }
             )
 
             GrapesTextInput(
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier,
                 value = filledTextFieldValue,
                 isError = true,
                 placeholderValue = "This is a placeholder",
+                helperText = "This is an error helper text",
                 onValueChange = {
                     filledTextFieldValue = it
                 }
             )
 
             GrapesTextInput(
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier,
                 value = emptyTextFieldValue,
                 enabled = false,
                 placeholderValue = "This is a disabled placeholder",
@@ -125,10 +130,11 @@ fun PreviewGrapesTextField() {
             )
 
             GrapesTextInput(
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier,
                 value = disabledTextFieldValue,
                 enabled = false,
-                placeholderValue = "This is a placeholder",
+                placeholderValue = "This is a disabled placeholder",
+                helperText = "This is disabled helper text",
                 onValueChange = {
                     disabledTextFieldValue = it
                 }

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/GrapesTextInput.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/GrapesTextInput.kt
@@ -3,16 +3,29 @@ package com.spendesk.grapes.compose.textfield
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.material.Switch
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
@@ -63,29 +76,22 @@ fun GrapesTextInput(
 @Composable
 @Preview
 fun PreviewGrapesTextField() {
-    var emptyTextFieldValue by remember {
+
+    var isEnabled by remember { mutableStateOf(true) }
+    var isError by remember { mutableStateOf(false) }
+    var textFieldValue by remember {
         mutableStateOf(
             TextFieldValue(
                 text = ""
             )
         )
     }
+    var helperText by remember { mutableStateOf("") }
 
-    var filledTextFieldValue by remember {
-        mutableStateOf(
-            TextFieldValue(
-                text = "This is a text value"
-            )
-        )
-    }
-
-    var disabledTextFieldValue by remember {
-        mutableStateOf(
-            TextFieldValue(
-                text = "This is a disabled text value"
-            )
-        )
-    }
+    // Option States
+    var hasTextValue by remember { mutableStateOf(false) }
+    var hasHelperText by remember { mutableStateOf(false) }
+    var canToggleError by remember { mutableStateOf(isEnabled) }
 
     GrapesTheme {
         Column(
@@ -95,51 +101,129 @@ fun PreviewGrapesTextField() {
                 .verticalScroll(rememberScrollState())
                 .padding(8.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
+            horizontalAlignment = Alignment.Start,
         ) {
 
+            Column(
+                modifier = Modifier
+                    .padding(bottom = 12.dp)
+                    .fillMaxWidth()
+                    .background(GrapesTheme.colors.mainNeutralLight)
+                    .padding(8.dp)
+
+
+            ) {
+                PreviewOptionsRow(
+                    options = {
+                        PreviewRowOptionSwitch(
+                            label = "Show text input value",
+                            isChecked = hasTextValue,
+                            onCheckedChange = { isChecked ->
+                                hasTextValue = isChecked
+                                textFieldValue = TextFieldValue(
+                                    text = "This is a text input value".takeIf { isChecked }.orEmpty()
+                                )
+                            }
+                        )
+
+                        PreviewRowOptionSwitch(
+                            label = "Show helper text",
+                            isChecked = hasHelperText,
+                            onCheckedChange = { isChecked ->
+                                hasHelperText = isChecked
+                                helperText = "Helper text".takeIf { isChecked }.orEmpty()
+                            }
+                        )
+                    }
+                )
+
+                PreviewOptionsRow(
+                    options = {
+                        PreviewRowOptionSwitch(
+                            label = "Is Enabled",
+                            isChecked = isEnabled,
+                            onCheckedChange = { isChecked ->
+                                canToggleError = isChecked
+                                if (isChecked.not() && isError) {
+                                    isError = false
+                                }
+
+                                isEnabled = isChecked
+                            }
+                        )
+
+                        PreviewRowOptionSwitch(
+                            label = "Is Error",
+                            isEnable = canToggleError,
+                            isChecked = isError,
+                            onCheckedChange = { isChecked ->
+                                isError = isChecked
+                            }
+                        )
+                    }
+                )
+            }
+
+            // ----
             GrapesTextInput(
-                modifier = Modifier,
-                value = emptyTextFieldValue,
+                modifier = Modifier.fillMaxWidth(),
+                value = textFieldValue,
                 placeholderValue = "This is a placeholder",
-                helperText = "This is helper text",
+                enabled = isEnabled,
+                helperText = helperText,
+                isError = isError,
                 onValueChange = {
-                    emptyTextFieldValue = it
-                }
-            )
-
-            GrapesTextInput(
-                modifier = Modifier,
-                value = filledTextFieldValue,
-                isError = true,
-                placeholderValue = "This is a placeholder",
-                helperText = "This is an error helper text",
-                onValueChange = {
-                    filledTextFieldValue = it
-                }
-            )
-
-            GrapesTextInput(
-                modifier = Modifier,
-                value = emptyTextFieldValue,
-                enabled = false,
-                placeholderValue = "This is a disabled placeholder",
-                onValueChange = {
-                    emptyTextFieldValue = it
-                }
-            )
-
-            GrapesTextInput(
-                modifier = Modifier,
-                value = disabledTextFieldValue,
-                enabled = false,
-                placeholderValue = "This is a disabled placeholder",
-                helperText = "This is disabled helper text",
-                onValueChange = {
-                    disabledTextFieldValue = it
+                    textFieldValue = it
                 }
             )
         }
     }
 }
+
+@Composable
+private fun PreviewOptionsRow(
+    options: @Composable RowScope.() -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceAround
+    ) {
+        options()
+    }
+}
+
+@Composable
+private fun PreviewRowOptionSwitch(
+    label: String,
+    modifier: Modifier = Modifier,
+    isEnable: Boolean = true,
+    isChecked: Boolean = false,
+    onCheckedChange: (isChecked: Boolean) -> Unit = {},
+) {
+    Row(
+        modifier = modifier
+            .height(IntrinsicSize.Min)
+            .toggleable(
+                role = Role.Switch,
+                enabled = isEnable,
+                value = isChecked,
+                onValueChange = onCheckedChange,
+            ),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            modifier = Modifier,
+            text = label,
+            style = GrapesTheme.typography.bodyRegular,
+        )
+        Switch(
+            modifier = Modifier,
+            checked = isChecked,
+            enabled = isEnable,
+            onCheckedChange = null
+        )
+    }
+}
+
 // endregion: Preview


### PR DESCRIPTION
# GrapesTextInput
- v1 of the composable TextInput
Figma: 
<img width="635" alt="Screenshot 2023-01-13 at 16 04 52" src="https://user-images.githubusercontent.com/112860634/212351862-674eb751-77ef-4e12-b5c1-95629d4f37f9.png">

## Demo
![textInput](https://user-images.githubusercontent.com/112860634/212353552-82d6cfbb-a8a4-4d3f-9daf-25157a59fad9.gif)

## How to use

```kotlin
GrapesTextInput(
                modifier = Modifier,
                value = TextFieldValue(text=""),
                placeholderValue = "This is a placeholder",
                enabled = (true|false),
                helperText = "Helper text" (optional),
                isError = (true|false),
                onValueChange = {
                    
                }
            )
```