### PR TITLE
Fix checkbox toggle in GrapesCheckboxText

### DIFF
--- a/library-compose/src/main/java/com/spendesk/grapes/compose/selectors/GrapesCheckbox.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/selectors/GrapesCheckbox.kt
@@ -21,7 +21,7 @@ import com.spendesk.grapes.compose.theme.GrapesTheme
 @Composable
 fun GrapesCheckbox(
     isChecked: Boolean,
-    onCheckedChange: ((Boolean) -> Unit),
+    onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     isEnabled: Boolean = true,
 ) =

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/selectors/GrapesCheckboxText.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/selectors/GrapesCheckboxText.kt
@@ -27,25 +27,27 @@ import com.spendesk.grapes.compose.theme.GrapesTheme
 @Composable
 fun GrapesCheckboxText(
     text: String,
-    onChecked: ((Boolean) -> Unit),
+    onChecked: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     isChecked: Boolean = false,
     isEnabled: Boolean = true,
-) =
+) {
+    val onToggleCheck = { onChecked(!isChecked) }
+
     Row(
         modifier = modifier
             .clickable(
                 enabled = isEnabled,
                 onClickLabel = text,
                 role = Role.Checkbox,
-                onClick = { onChecked(!isChecked) }
+                onClick = onToggleCheck
             ),
         verticalAlignment = Alignment.CenterVertically
     ) {
         GrapesCheckbox(
             isChecked = isChecked,
             isEnabled = isEnabled,
-            onCheckedChange = { },
+            onCheckedChange = { onToggleCheck.invoke() },
         )
         Spacer(Modifier.padding(end = GrapesTheme.dimensions.paddingSmall))
         Text(
@@ -54,6 +56,7 @@ fun GrapesCheckboxText(
             style = GrapesTheme.typography.bodyRegular
         )
     }
+}
 
 @Composable
 @Preview(
@@ -72,7 +75,7 @@ private fun GrapesCheckboxTextPreview() {
 
             var isChecked by remember { mutableStateOf(false) }
 
-            GrapesCheckboxText(text = "Checkbox unselected and enabled", isChecked = isChecked, isEnabled = true, onChecked = { isChecked = it })
+            GrapesCheckboxText(text = "Checkbox toggle", isChecked = isChecked, isEnabled = true, onChecked = { isChecked = it })
         }
     }
 }


### PR DESCRIPTION
When clicking on the checkbox itself (not on the text), the click event was not forwarded.