### PR TITLE
Avoid importing alpha material dependency with material3

### DIFF
--- a/library-compose/build.gradle
+++ b/library-compose/build.gradle
@@ -58,24 +58,24 @@ dependencies {
     }
 
     // Compose
-    api platform("androidx.compose:compose-bom:$compose_bom_version")
+    implementation platform("androidx.compose:compose-bom:$compose_bom_version")
 
-    api("androidx.compose.ui:ui")
-    api("androidx.compose.runtime:runtime")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.runtime:runtime")
     // Tooling support (Previews, etc.)
-    api("androidx.compose.ui:ui-tooling")
+    implementation("androidx.compose.ui:ui-tooling")
     // Foundation (Border, Background, Box, Image, Scroll, shapes, animations, etc.)
-    api("androidx.compose.foundation:foundation")
+    implementation("androidx.compose.foundation:foundation")
     // Material Design 2 & 3 while migration is pending.
-    api("androidx.compose.material:material")
-    api("androidx.compose.material3:material3:$compose_material_3_version")
+    implementation("androidx.compose.material:material")
+    implementation("androidx.compose.material3:material3:$compose_material_3_version")
 
     // Material design icons
-    api("androidx.lifecycle:lifecycle-runtime-ktx:2.6.0")
-    api("androidx.compose.material:material-icons-core")
-    api("androidx.compose.material:material-icons-extended")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.0")
+    implementation("androidx.compose.material:material-icons-core")
+    implementation("androidx.compose.material:material-icons-extended")
     // Integration with observables
-    api("androidx.compose.runtime:runtime-rxjava2")
+    implementation("androidx.compose.runtime:runtime-rxjava2")
 
     // UI Tests
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")

--- a/library-compose/build.gradle
+++ b/library-compose/build.gradle
@@ -68,7 +68,10 @@ dependencies {
     implementation("androidx.compose.foundation:foundation")
     // Material Design 2 & 3 while migration is pending.
     implementation("androidx.compose.material:material")
-    implementation("androidx.compose.material3:material3:$compose_material_3_version")
+    implementation("androidx.compose.material3:material3:$compose_material_3_version") {
+        exclude group: 'androidx.compose.material', module: 'material-icons-core'
+        exclude group: 'androidx.compose.material', module: 'material-ripple'
+    }
 
     // Material design icons
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.0")

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/appbar/GrapesTopAppBar.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/appbar/GrapesTopAppBar.kt
@@ -2,7 +2,12 @@ package com.spendesk.grapes.compose.appbar
 
 import android.util.Log
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/badge/Badge.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/badge/Badge.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Text
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/bucket/GrapesBucket.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/bucket/GrapesBucket.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Text
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/bucket/GrapesBucketContainer.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/bucket/GrapesBucketContainer.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Text
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/bucket/GrapesBucketHeadline.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/bucket/GrapesBucketHeadline.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Text
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/button/GrapesButtonRippleTheme.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/button/GrapesButtonRippleTheme.kt
@@ -1,6 +1,6 @@
 package com.spendesk.grapes.compose.button
 
-import androidx.compose.material3.LocalContentColor
+import androidx.compose.material.LocalContentColor
 import androidx.compose.material.ripple.RippleTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/button/GrapesCoreButton.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/button/GrapesCoreButton.kt
@@ -18,9 +18,9 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonColors
 import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.LocalContentColor
 import androidx.compose.material.ProvideTextStyle
 import androidx.compose.material.ripple.LocalRippleTheme
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/icons/GrapesIcon.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/icons/GrapesIcon.kt
@@ -1,7 +1,7 @@
 package com.spendesk.grapes.compose.icons
 
 import androidx.annotation.DrawableRes
-import androidx.compose.material3.Icon
+import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/icons/GrapesSurface.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/icons/GrapesSurface.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.Surface
+import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/listitem/Divider.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/listitem/Divider.kt
@@ -3,8 +3,8 @@ package com.spendesk.grapes.compose.listitem
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.Divider
-import androidx.compose.material3.Text
+import androidx.compose.material.Divider
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/listitem/IconAction.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/listitem/IconAction.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Text
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/selectors/GrapesCheckboxText.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/selectors/GrapesCheckboxText.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Text
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/GrapesBaseTextField.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/GrapesBaseTextField.kt
@@ -17,9 +17,9 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Text
+import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
@@ -40,7 +40,6 @@ import com.spendesk.grapes.compose.theme.GrapesTheme
  * @since 06/01/2023, Fri
  **/
 
-@ExperimentalMaterial3Api
 @Composable
 internal fun GrapesBaseTextField(
     value: String,
@@ -117,7 +116,6 @@ internal fun GrapesBaseTextField(
     )
 }
 
-@ExperimentalMaterial3Api
 @Composable
 internal fun GrapesBaseTextField(
     value: TextFieldValue,
@@ -214,7 +212,7 @@ internal fun GrapesHelperText(
     }
 }
 
-@ExperimentalMaterial3Api
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 private fun GrapesCoreTextField(
     value: TextFieldValue,
@@ -278,7 +276,7 @@ private fun GrapesCoreTextField(
                 },
                 leadingIcon = leadingIcon,
                 trailingIcon = trailingIcon,
-                container = {
+                border = {
                     GrapesTextFieldDefaults.BorderBox(
                         enabled = enabled,
                         isError = isError,

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/GrapesTextInput.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/GrapesTextInput.kt
@@ -20,9 +20,8 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.ScaffoldState
 import androidx.compose.material.SnackbarDuration
 import androidx.compose.material.rememberScaffoldState
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Switch
-import androidx.compose.material3.Text
+import androidx.compose.material.Switch
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -48,7 +47,6 @@ import kotlinx.coroutines.launch
  * @author jean-philippe
  * @since 05/01/2023, Thu
  **/
-@ExperimentalMaterial3Api
 @Composable
 fun GrapesTextInput(
     value: TextFieldValue,
@@ -89,7 +87,6 @@ fun GrapesTextInput(
     )
 }
 
-@ExperimentalMaterial3Api
 @Composable
 fun GrapesTextInput(
     value: String,
@@ -132,7 +129,6 @@ fun GrapesTextInput(
 
 // region: Preview
 
-@ExperimentalMaterial3Api
 @Composable
 @Preview
 fun PreviewGrapesTextField() {

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/PasswordTextInput.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/PasswordTextInput.kt
@@ -9,9 +9,8 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -30,7 +29,6 @@ import com.spendesk.grapes.compose.theme.GrapesTheme
  * @author Kélian CLERC
  * @since 24/02/2023
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PasswordTextInput(
     value: String,

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/theme/GrapesTheme.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/theme/GrapesTheme.kt
@@ -2,7 +2,7 @@ package com.spendesk.grapes.compose.theme
 
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.material3.LocalContentColor
+import androidx.compose.material.LocalContentColor
 import androidx.compose.material.ripple.LocalRippleTheme
 import androidx.compose.material.ripple.RippleTheme
 import androidx.compose.material.ripple.rememberRipple

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -104,4 +104,29 @@ dependencies {
 
     // REFLECTION
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.7.10"
+
+    implementation platform("androidx.compose:compose-bom:$compose_bom_version")
+
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.runtime:runtime")
+    // Tooling support (Previews, etc.)
+    implementation("androidx.compose.ui:ui-tooling")
+    // Foundation (Border, Background, Box, Image, Scroll, shapes, animations, etc.)
+    implementation("androidx.compose.foundation:foundation")
+    // Material Design 2 & 3 while migration is pending.
+    implementation("androidx.compose.material:material")
+    implementation("androidx.compose.material3:material3:$compose_material_3_version") {
+        exclude group: 'androidx.compose.material', module: 'material-icons-core'
+        exclude group: 'androidx.compose.material', module: 'material-ripple'
+    }
+
+    // Material design icons
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.0")
+    implementation("androidx.compose.material:material-icons-core")
+    implementation("androidx.compose.material:material-icons-extended")
+    // Integration with observables
+    implementation("androidx.compose.runtime:runtime-rxjava2")
+
+    // UI Tests
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
 }


### PR DESCRIPTION
Consider reverting these changes when intercom lib supports the new stable version of material 1.4.0