### PR TITLE
Account activation components tweaks

### DIFF
--- a/library-compose/src/main/java/com/spendesk/grapes/compose/message/PasswordValidation.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/message/PasswordValidation.kt
@@ -1,9 +1,11 @@
 package com.spendesk.grapes.compose.message
 
+import androidx.annotation.DrawableRes
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Checkbox
+import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -22,7 +25,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.spendesk.grapes.compose.theme.GrapesTheme
 
@@ -57,16 +62,27 @@ private fun PasswordValidationItem(
         if (isValid) PasswordValidationDefaults.SuccessColor else PasswordValidationDefaults.ErrorColor
     )
 
+    @DrawableRes
+    val itemIcon: Int = if (isValid) {
+        PasswordValidationDefaults.ValidIcon
+    } else {
+        PasswordValidationDefaults.InvalidIcon
+    }
+
+    val iconSize: Dp = if (isValid) {
+        PasswordValidationDefaults.ValidationSuccessItemSize
+    } else {
+        PasswordValidationDefaults.ValidationItemSize
+    }
+
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(GrapesTheme.dimensions.paddingSmall)
     ) {
-        Spacer(
-            modifier = Modifier
-                .size(PasswordValidationDefaults.ValidationItemCircleSize)
-                .background(itemColor, CircleShape)
-        )
+        Box(modifier = Modifier.size(PasswordValidationDefaults.ValidationBoxSize), contentAlignment = Alignment.Center) {
+            Icon(painter = painterResource(id = itemIcon), contentDescription = null, tint = itemColor, modifier = Modifier.size(iconSize))
+        }
         Text(text = label, style = GrapesTheme.typography.bodyS, color = itemColor)
     }
 }

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/message/PasswordValidationDefaults.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/message/PasswordValidationDefaults.kt
@@ -1,9 +1,11 @@
 package com.spendesk.grapes.compose.message
 
+import androidx.annotation.DrawableRes
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.spendesk.grapes.compose.R
 import com.spendesk.grapes.compose.theme.GrapesTheme
 
 /**
@@ -12,8 +14,13 @@ import com.spendesk.grapes.compose.theme.GrapesTheme
  */
 @Immutable
 object PasswordValidationDefaults {
-    val ValidationItemCircleSize = 6.dp
+    val ValidationItemSize = 6.dp
+    val ValidationSuccessItemSize = 10.dp
+    val ValidationBoxSize = 16.dp
 
     val SuccessColor: Color @Composable get() = GrapesTheme.colors.mainSuccessNormal
     val ErrorColor: Color @Composable get() = GrapesTheme.colors.mainAlertNormal
+
+    @DrawableRes val ValidIcon: Int = R.drawable.ic_valid_tick
+    @DrawableRes val InvalidIcon: Int = R.drawable.ic_neutral_tick
 }

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/select/GrapesSelect.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/select/GrapesSelect.kt
@@ -102,7 +102,7 @@ private fun Select(
         horizontalArrangement = Arrangement.spacedBy(GrapesTheme.dimensions.paddingLarge),
         modifier = modifier
             .background(itemColor, shape = RoundedCornerShape(50, 50, radiusSize, radiusSize))
-            .border(1.dp, GrapesTheme.colors.mainPrimaryLighter, shape = RoundedCornerShape(50, 50, radiusSize, radiusSize))
+            .border(1.dp, GrapesTheme.colors.mainNeutralLight, shape = RoundedCornerShape(50, 50, radiusSize, radiusSize))
             .padding(horizontal = GrapesTheme.dimensions.paddingLarge, vertical = GrapesTheme.dimensions.paddingMedium)
     ) {
         Text(text = label, style = GrapesTheme.typography.titleS, color = contentColor)

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/GrapesTextFieldDefaults.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/textfield/GrapesTextFieldDefaults.kt
@@ -93,13 +93,14 @@ object GrapesTextFieldDefaults {
     @Composable
     fun textFieldColors(
         textColor: Color = GrapesTheme.colors.mainNeutralDarkest,
-        disabledTextColor: Color = textColor.copy(ContentAlpha.disabled),
+        disabledTextColor: Color = GrapesTheme.colors.mainNeutralDarkest,
         backgroundColor: Color = GrapesTheme.colors.mainWhite,
+        disabledBackgroundColor: Color = GrapesTheme.colors.mainNeutralLighter,
         cursorColor: Color = GrapesTheme.colors.mainPrimaryLight,
         errorCursorColor: Color = GrapesTheme.colors.mainAlertNormal,
         focusedBorderColor: Color = GrapesTheme.colors.mainNeutralLight,
         unfocusedBorderColor: Color = GrapesTheme.colors.mainNeutralLight,
-        disabledBorderColor: Color = GrapesTheme.colors.mainNeutralLighter,
+        disabledBorderColor: Color = GrapesTheme.colors.mainNeutralLight,
         errorBorderColor: Color = GrapesTheme.colors.mainAlertNormal,
         leadingIconColor: Color = Color.Yellow, // Todo replace
         disabledLeadingIconColor: Color = Color.Yellow, // Todo replace
@@ -132,6 +133,7 @@ object GrapesTextFieldDefaults {
         disabledTrailingIconColor = disabledTrailingIconColor,
         errorTrailingIconColor = errorTrailingIconColor,
         backgroundColor = backgroundColor,
+        disabledBackgroundColor = disabledBackgroundColor,
         focusedLabelColor = focusedLabelColor,
         unfocusedLabelColor = unfocusedLabelColor,
         disabledLabelColor = disabledLabelColor,
@@ -161,6 +163,7 @@ private data class DefaultGrapesGrapesTextFieldColors(
     private val disabledTrailingIconColor: Color,
     private val errorTrailingIconColor: Color,
     private val backgroundColor: Color,
+    private val disabledBackgroundColor: Color,
     private val focusedLabelColor: Color,
     private val unfocusedLabelColor: Color,
     private val disabledLabelColor: Color,
@@ -232,7 +235,7 @@ private data class DefaultGrapesGrapesTextFieldColors(
 
     @Composable
     override fun backgroundColor(enabled: Boolean): State<Color> {
-        return rememberUpdatedState(backgroundColor)
+        return rememberUpdatedState(if (enabled) backgroundColor else disabledBackgroundColor)
     }
 
     @Composable

--- a/library-compose/src/main/res/drawable/ic_neutral_tick.xml
+++ b/library-compose/src/main/res/drawable/ic_neutral_tick.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="4dp"
+    android:height="4dp"
+    android:viewportWidth="4"
+    android:viewportHeight="4">
+  <path
+      android:pathData="M2,2m-2,0a2,2 0,1 1,4 0a2,2 0,1 1,-4 0"
+      android:fillColor="#48465E"/>
+</vector>

--- a/library-compose/src/main/res/drawable/ic_valid_tick.xml
+++ b/library-compose/src/main/res/drawable/ic_valid_tick.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="10dp"
+    android:height="8dp"
+    android:viewportWidth="10"
+    android:viewportHeight="8">
+  <path
+      android:pathData="M1.445,4L4.112,6.667L8.556,1.333"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#0B831B"/>
+</vector>


### PR DESCRIPTION
Fix a border color for grapesSelector,
![Capture d’écran 2023-04-06 à 14 25 00](https://user-images.githubusercontent.com/26220096/230379953-43a2a60a-ad93-4ce4-85c4-d37ca793be88.png)


Fix text field disabled style
<img width="437" alt="Capture d’écran 2023-04-06 à 14 27 01" src="https://user-images.githubusercontent.com/26220096/230379974-35fbbb1f-0844-4ffb-b8bf-15a673d11c10.png">

FIx Password validation ticks

https://user-images.githubusercontent.com/26220096/230380000-f3a8a60f-3d92-40d6-82dc-a7453d3f5b51.mov

