### PR TITLE
Prevent workflow trigger on PR with main as base branch

### DIFF
--- a/.github/workflows/publishSampleOnAppDistrib.yml
+++ b/.github/workflows/publishSampleOnAppDistrib.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   publishDebugApp:
+    if: ${{ github.event_name == 'push' || github.event.pull_request.merged == true }} # Necessary to make sure a pull request from main will not trigger the job
     name: Publish sample app to Firebase app distrib
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
It seems that it was the case when creating the merge request: 
https://github.com/Spendesk/grapes-android/pull/206/checks

We'll see if this fixes it. 
We had the same issue on spendesk where the merge request was triggering another build publish to the play store