### PR TITLE
fix: Selector & Badge

### DIFF
--- a/library-compose/src/main/java/com/spendesk/grapes/compose/badge/GrapesBadge.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/badge/GrapesBadge.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/badge/GrapesBadge.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/badge/GrapesBadge.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentSize
@@ -88,7 +89,7 @@ private fun GrapesBadge(
     Box(
         modifier = modifier
             .widthIn(min = GrapesBadgeDefaults.MinWidth)
-            .height(GrapesBadgeDefaults.Height)
+            .heightIn(min = GrapesBadgeDefaults.MinHeight)
             .background(
                 color = colors.backgroundColor(),
                 shape = GrapesBadgeDefaults.backgroundShape(),
@@ -131,13 +132,20 @@ private fun GrapesBadge(
     }
 }
 
-internal data class Digit(val digitChar: Char, val fullNumber: Int, val place: Int) {
+private data class Digit(val digitChar: Char, val fullNumber: Int, val place: Int) {
 
     override fun equals(other: Any?): Boolean {
         return when (other) {
             is Digit -> digitChar == other.digitChar
             else -> super.equals(other)
         }
+    }
+
+    override fun hashCode(): Int {
+        var result = digitChar.hashCode()
+        result = 31 * result + fullNumber
+        result = 31 * result + place
+        return result
     }
 }
 

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/badge/GrapesBadgeDefaults.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/badge/GrapesBadgeDefaults.kt
@@ -37,7 +37,7 @@ object GrapesBadgeDefaults {
     const val MORE_INDICATOR = "+"
 
     val MinWidth = 24.dp
-    val Height = 24.dp
+    val MinHeight = 24.dp
     val HorizontalPadding = 4.dp
 
     @Composable

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/select/GrapesSelector.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/select/GrapesSelector.kt
@@ -1,16 +1,11 @@
 package com.spendesk.grapes.compose.select
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material3.Icon
@@ -24,6 +19,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.spendesk.grapes.compose.badge.GrapesAlertBadge
 import com.spendesk.grapes.compose.theme.GrapesTheme
 
 /**
@@ -34,7 +30,7 @@ import com.spendesk.grapes.compose.theme.GrapesTheme
 fun GrapesSelector(
     label: String,
     modifier: Modifier = Modifier,
-    badge: @Composable (BoxScope.() -> Unit)? = null,
+    badge: @Composable (() -> Unit)? = null,
     colors: GrapesSelectorColors = GrapesSelectorDefaults.defaultColors(),
     onClick: () -> Unit,
 ) {
@@ -63,7 +59,7 @@ fun GrapesSelector(
 internal fun GrapesSelector(
     label: String,
     modifier: Modifier = Modifier,
-    badge: @Composable (BoxScope.() -> Unit)? = null,
+    badge: @Composable (() -> Unit)? = null,
     shape: Shape = GrapesTheme.shapes.shape4,
     contentPadding: PaddingValues = PaddingValues(
         horizontal = GrapesTheme.dimensions.spacing3,
@@ -99,10 +95,7 @@ internal fun GrapesSelector(
             )
 
             if (badge != null) {
-                Box(
-                    content = badge,
-                    modifier = Modifier.size(GrapesTheme.dimensions.sizing4),
-                )
+                badge()
             }
 
             icon()
@@ -149,13 +142,10 @@ private fun GrapesSelectorPreview() {
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             GrapesSelector(
+                modifier = Modifier,
                 label = "Spendesk UK",
                 badge = {
-                    Box(
-                        modifier = Modifier
-                            .size(48.dp)
-                            .background(Color.Red, CircleShape),
-                    )
+                    GrapesAlertBadge(countValue = 24)
                 },
                 onClick = {},
             )


### PR DESCRIPTION
### Description

#### Badge
Fix  Badge Modifier `heightIn` preventing text from overflowing if the user has a custom text size

#### Selector
Badge not required to be inside a Box 

### Demo

| Before | After |
| :---: | :---: |
| ![Screenshot 2024-04-08 at 14 06 24](https://github.com/Spendesk/grapes-android/assets/112860634/5378de01-8d19-4b37-9210-e3f03c760f12) | ![Screenshot 2024-04-08 at 14 08 21](https://github.com/Spendesk/grapes-android/assets/112860634/15360d32-bd09-4660-8601-4bfe633a2c63) |
| ![Screenshot 2024-04-08 at 14 28 44](https://github.com/Spendesk/grapes-android/assets/112860634/d37e0a7a-9c14-4596-a831-387bfe6e045c) |  ![Screenshot 2024-04-08 at 14 27 35](https://github.com/Spendesk/grapes-android/assets/112860634/31ecb6db-546c-44cc-a4cd-58f88afb62e8) |
