### PR TITLE
Fix min edit text size for 6 digits long text

### DIFF
--- a/library-compose/src/main/java/com/spendesk/grapes/compose/edittext/windowed/WindowEditText.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/edittext/windowed/WindowEditText.kt
@@ -4,11 +4,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
@@ -99,6 +101,7 @@ internal fun WindowEditTextBase(
 
     Box(modifier = modifier, contentAlignment = Alignment.Center) {
         BasicTextField(
+            modifier = Modifier.width(IntrinsicSize.Min),
             value = formattedText,
             onValueChange = { newValue ->
                 onTextChange(sanitizeWindowedEditTextContent(newValue, maxLength))
@@ -149,6 +152,12 @@ fun WindowEditTextPreview() {
             }
             WindowEditText(
                 text = content, onTextChange = { content = it }
+            )
+            WindowEditText(
+                text = content,
+                onTextChange = { content = it },
+                windowLength = 3,
+                maxLength = 6,
             )
         }
     }


### PR DESCRIPTION
Before

![Capture d’écran 2024-05-30 à 12 02 48](https://github.com/Spendesk/grapes-android/assets/26220096/c4138be5-b5e3-4401-988a-711d777621d5)


After

![Capture d’écran 2024-05-30 à 12 03 07](https://github.com/Spendesk/grapes-android/assets/26220096/af70b3a8-e03c-45d8-98e6-4c657bf9c9f4)
