### PR TITLE
Fix text option group on click effect

### DIFF
--- a/library-compose/src/main/java/com/spendesk/grapes/compose/optiongroup/GrapesTextOptionGroup.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/optiongroup/GrapesTextOptionGroup.kt
@@ -4,13 +4,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
+import androidx.compose.material3.CardDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -21,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.spendesk.grapes.compose.optiongroup.internal.GrapesOptionGroupItemDefaults
 import com.spendesk.grapes.compose.optiongroup.model.GrapesTextOptionGroupUiModel
 import com.spendesk.grapes.compose.theme.GrapesTheme
 import kotlinx.collections.immutable.ImmutableList
@@ -50,36 +49,28 @@ fun GrapesTextOptionGroup(
             modifier = Modifier.fillMaxWidth(),
         ) {
             items.forEachIndexed { index, item ->
-                if (item.isSelected) {
-                    GrapesTextOptionGroupItem(
-                        text = item.text,
-                        isSelected = true,
-                        onClick = { /* item already selected, do nothing */ },
-                        modifier = Modifier
-                            .weight(1f)
-                    )
+                val elevation = if (item.isSelected) {
+                    GrapesOptionGroupItemDefaults.elevation()
                 } else {
-                    TextButton(
-                        onClick = { onItemSelected(item) },
-                        shape = GrapesTheme.shapes.shape2,
-                        modifier = modifier
-                            .fillMaxHeight()
-                            .weight(1f)
-                    ) {
-                        Text(
-                            text = item.text,
-                            color = GrapesTheme.colors.neutralDark,
-                            style = GrapesTheme.typography.bodyM,
-                        )
-                    }
-                    if (index < items.lastIndex && !items[index + 1].isSelected) {
-                        Box(
-                            modifier = Modifier
-                                .width(1.dp)
-                                .height(16.dp)
-                                .background(GrapesTheme.colors.neutralLighter)
-                        )
-                    }
+                    CardDefaults.cardElevation()
+                }
+                GrapesTextOptionGroupItem(
+                    text = item.text,
+                    isSelected = item.isSelected,
+                    onClick = { onItemSelected(item) },
+                    elevation = elevation,
+                    border = GrapesOptionGroupItemDefaults.border(
+                        unselectedBorder = null,
+                    ),
+                    modifier = Modifier.weight(1f)
+                )
+                if (index < items.lastIndex && !items[index + 1].isSelected) {
+                    Box(
+                        modifier = Modifier
+                            .width(1.dp)
+                            .height(16.dp)
+                            .background(GrapesTheme.colors.neutralLighter)
+                    )
                 }
             }
         }

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/optiongroup/GrapesTextOptionGroupItem.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/optiongroup/GrapesTextOptionGroupItem.kt
@@ -4,12 +4,16 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.CardElevation
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.spendesk.grapes.compose.optiongroup.internal.GrapesOptionGroupItem
+import com.spendesk.grapes.compose.optiongroup.internal.GrapesOptionGroupItemBorder
+import com.spendesk.grapes.compose.optiongroup.internal.GrapesOptionGroupItemColors
+import com.spendesk.grapes.compose.optiongroup.internal.GrapesOptionGroupItemDefaults
 import com.spendesk.grapes.compose.theme.GrapesTheme
 
 /**
@@ -24,11 +28,19 @@ fun GrapesTextOptionGroupItem(
     isSelected: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    border: GrapesOptionGroupItemBorder? = GrapesOptionGroupItemDefaults.border(),
+    elevation: CardElevation = GrapesOptionGroupItemDefaults.elevation(),
+    colors: GrapesOptionGroupItemColors = GrapesOptionGroupItemDefaults.colors(
+        unselectedContentColor = GrapesTheme.colors.neutralDark,
+    ),
 ) {
     GrapesOptionGroupItem(
         isSelected = isSelected,
-        onClick = onClick,
+        border = border,
         contentDescription = text,
+        elevation = elevation,
+        colors = colors,
+        onClick = onClick,
         modifier = modifier.widthIn(min = minWidth)
     ) {
         Text(

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/optiongroup/internal/GrapesOptionGroupItem.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/optiongroup/internal/GrapesOptionGroupItem.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CardElevation
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -43,24 +44,24 @@ internal fun GrapesOptionGroupItem(
     modifier: Modifier = Modifier,
     alignment: Alignment = Alignment.Center,
     elevation: CardElevation = GrapesOptionGroupItemDefaults.elevation(),
-    colors: CardColors = if (isSelected) {
-        GrapesOptionGroupItemDefaults.selectedColors()
-    } else {
-        GrapesOptionGroupItemDefaults.unselectedColors()
-    },
-    border: BorderStroke = if (isSelected) {
-        GrapesOptionGroupItemDefaults.selectedBorder()
-    } else {
-        GrapesOptionGroupItemDefaults.unselectedBorder()
-    },
+    colors: GrapesOptionGroupItemColors = GrapesOptionGroupItemDefaults.colors(),
+    border: GrapesOptionGroupItemBorder? = GrapesOptionGroupItemDefaults.border(),
     content: @Composable () -> Unit,
 ) {
     Card(
-        colors = colors,
-        border = border,
         elevation = elevation,
         shape = GrapesTheme.shapes.shape2,
         onClick = onClick,
+        border = if (isSelected) {
+            border?.selectedBorder
+        } else {
+            border?.unselectedBorder
+        },
+        colors = if (isSelected) {
+            colors.selectedColors
+        } else {
+            colors.unselectedColors
+        },
         modifier = modifier
             .width(IntrinsicSize.Max)
             .height(IntrinsicSize.Max)
@@ -75,36 +76,44 @@ internal fun GrapesOptionGroupItem(
     }
 }
 
+@Immutable
+data class GrapesOptionGroupItemColors(
+    val selectedColors: CardColors,
+    val unselectedColors: CardColors,
+)
+
+@Immutable
+data class GrapesOptionGroupItemBorder(
+    val selectedBorder: BorderStroke?,
+    val unselectedBorder: BorderStroke?,
+)
+
 internal object GrapesOptionGroupItemDefaults {
 
     @Composable
-    fun selectedColors(
-        containerColor: Color = GrapesTheme.colors.primaryLightest,
-        contentColor: Color = GrapesTheme.colors.primaryNormal,
-    ): CardColors = CardDefaults.cardColors(
-        containerColor = containerColor,
-        contentColor = contentColor,
+    fun colors(
+        selectedContainerColor: Color = GrapesTheme.colors.primaryLightest,
+        selectedContentColor: Color = GrapesTheme.colors.primaryNormal,
+        unselectedContainerColor: Color = GrapesTheme.colors.structureSurface,
+        unselectedContentColor: Color = GrapesTheme.colors.structureComplementary,
+    ): GrapesOptionGroupItemColors = GrapesOptionGroupItemColors(
+        selectedColors = CardDefaults.cardColors(
+            containerColor = selectedContainerColor,
+            contentColor = selectedContentColor,
+        ),
+        unselectedColors = CardDefaults.cardColors(
+            containerColor = unselectedContainerColor,
+            contentColor = unselectedContentColor,
+        ),
     )
 
     @Composable
-    fun selectedBorder(): BorderStroke = BorderStroke(
-        width = 2.dp,
-        color = GrapesTheme.colors.primaryNormal,
-    )
-
-    @Composable
-    fun unselectedColors(
-        containerColor: Color = GrapesTheme.colors.structureSurface,
-        contentColor: Color = GrapesTheme.colors.structureComplementary,
-    ): CardColors = CardDefaults.cardColors(
-        containerColor = containerColor,
-        contentColor = contentColor,
-    )
-
-    @Composable
-    fun unselectedBorder(): BorderStroke = BorderStroke(
-        width = 1.dp,
-        color = GrapesTheme.colors.neutralLighter,
+    fun border(
+        selectedBorder: BorderStroke? = BorderStroke(2.dp, GrapesTheme.colors.primaryNormal),
+        unselectedBorder: BorderStroke? = BorderStroke(1.dp, GrapesTheme.colors.neutralLighter),
+    ): GrapesOptionGroupItemBorder = GrapesOptionGroupItemBorder(
+        selectedBorder = selectedBorder,
+        unselectedBorder = unselectedBorder,
     )
 
     @Composable
@@ -131,16 +140,14 @@ private fun PreviewGrapesOptionGroupItem() {
                 isSelected = isSelected,
                 onClick = { isSelected = !isSelected },
                 contentDescription = null,
-            ) {
-                icon()
-            }
+                content = { icon() }
+            )
             GrapesOptionGroupItem(
                 isSelected = !isSelected,
                 onClick = { isSelected = !isSelected },
                 contentDescription = null,
-            ) {
-                icon()
-            }
+                content = { icon() }
+            )
         }
     }
 }


### PR DESCRIPTION
There was a ripple effect on the item when isSelected changes from true to false maybe due to the apparition of the TextButton. Removing the TextButton foxes the problem.

| Before | After |
|-------|-------|
| <video src="https://github.com/user-attachments/assets/0136a09b-50b1-4b71-a9c1-b9af7bd75b1f" /> | <video src="https://github.com/user-attachments/assets/8576068a-10dc-4e79-be67-29f43dbb51ea" /> |
