### PR TITLE
feat: Add enable parameter to bucket and appbar components

### DIFF
--- a/library-compose/src/main/java/com/spendesk/grapes/compose/appbar/GrapesTopAppBarIcons.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/appbar/GrapesTopAppBarIcons.kt
@@ -20,11 +20,13 @@ fun GrapesTopAppBarIconButton(
     icon: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     onClick: () -> Unit = {},
+    enabled: Boolean = true,
 ) {
     IconButton(
         modifier = modifier,
         content = icon,
         onClick = onClick,
+        enabled = enabled,
     )
 }
 

--- a/library-compose/src/main/java/com/spendesk/grapes/compose/bucket/GrapesBucketHeadline.kt
+++ b/library-compose/src/main/java/com/spendesk/grapes/compose/bucket/GrapesBucketHeadline.kt
@@ -29,6 +29,7 @@ fun GrapesBucketHeadline(
     modifier: Modifier = Modifier,
     action: String? = null,
     actionColor: Color? = null,
+    actionEnabled: Boolean = true,
     onActionClicked: (() -> Unit)? = null
 ) {
     Row(modifier = modifier.fillMaxWidth()) {
@@ -43,7 +44,7 @@ fun GrapesBucketHeadline(
         if (action != null && actionColor != null) {
             Spacer(modifier = Modifier.size(GrapesTheme.dimensions.unit12))
             Text(
-                modifier = Modifier.clickable(onClick = onActionClicked ?: {}, onClickLabel = action, role = Role.Button),
+                modifier = Modifier.clickable(onClick = onActionClicked ?: {}, onClickLabel = action, role = Role.Button, enabled = actionEnabled),
                 text = action,
                 color = actionColor,
                 overflow = TextOverflow.Ellipsis,


### PR DESCRIPTION
This pull request introduces changes to enhance the functionality of UI components by adding an `enabled` parameter to control their interactive state. The most important changes are as follows:

Enhancements to UI components:

* [`library-compose/src/main/java/com/spendesk/grapes/compose/appbar/GrapesTopAppBarIcons.kt`](diffhunk://#diff-0b6b8ab0d8331fb932d95000886e9275eb01b347c53add37b33fb135e642b5e4R23-R29): Added an `enabled` parameter to the `GrapesTopAppBarIconButton` function to control whether the button is interactive.
* [`library-compose/src/main/java/com/spendesk/grapes/compose/bucket/GrapesBucketHeadline.kt`](diffhunk://#diff-2757a83ee5ef80298bc2caaa0b144e0d74f947dd36508bcfc6bb226a51ecc6e8R32): Added an `actionEnabled` parameter to the `GrapesBucketHeadline` function to control whether the action text is clickable.
* [`library-compose/src/main/java/com/spendesk/grapes/compose/bucket/GrapesBucketHeadline.kt`](diffhunk://#diff-2757a83ee5ef80298bc2caaa0b144e0d74f947dd36508bcfc6bb226a51ecc6e8L46-R47): Modified the `clickable` modifier of the action text to use the `actionEnabled` parameter, ensuring the clickability can be toggled.